### PR TITLE
Add prompt templates package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
             "npm:@devkade/pi-plan",
             "npm:pi-simplify",
             "npm:pi-add-dir",
+            "npm:pi-prompt-template-model",
             "npm:pi-themes",
             "npm:pi-cyber-ui",
             "npm:@victor-software-house/pi-curated-themes",

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -33,6 +33,7 @@ const PACKAGES = [
 	{ id: "plan", category: "core", source: "npm:@devkade/pi-plan", description: "/plan command", hint: "Read-only planning mode with approval-based execution." },
 	{ id: "simplify", category: "core", source: "npm:pi-simplify", description: "Code simplify review", hint: "Reviews recently changed code for clarity, consistency, and maintainability." },
 	{ id: "add-dir", category: "core", source: "npm:pi-add-dir", description: "Add external directories", hint: "Load configs and skills from additional project directories in the same Pi session." },
+	{ id: "prompt-templates", category: "core", source: "npm:pi-prompt-template-model", description: "Prompt template model switching", hint: "Add model, skill, and thinking frontmatter so prompt templates switch modes automatically." },
 	{ id: "plannotator", category: "ui", source: "npm:@plannotator/pi-extension", description: "Planning and annotation workflow", hint: "Plan + annotate large changes interactively." },
 	{ id: "powerbar", category: "ui", source: "npm:@juanibiapina/pi-powerbar", description: "Powerbar UI", hint: "Status line for Pi with live context." },
 	{ id: "extension-settings", category: "ui", source: "npm:@juanibiapina/pi-extension-settings", description: "Settings support for powerbar", hint: "Required by powerbar for its settings panel." },
@@ -195,7 +196,7 @@ ${bold("Default behaviour:")}
   - With --yes, --only, or --except the picker is skipped.
 
 ${bold("Categories:")}
-  core         foundations: sub-agents, MCP, web access, memory, …
+  core         foundations: sub-agents, MCP, web access, memory, prompt templates, …
   ui           powerbar, usage dashboard, plan-notator, …
   research     autonomous research / experiment loops
   frameworks   structured engineering workflows

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -50,6 +50,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -50,6 +50,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -66,7 +68,7 @@
 
     <h2>What is LazyPi?</h2>
     <p>
-      Pi is a minimalist coding agent. That minimalism is intentional — it ships as a blank canvas and lets the community build on top of it. The result is a rich ecosystem of packages: skills, themes, MCP adapters, memory systems, sub-agents, cost trackers, and engineering frameworks.
+      Pi is a minimalist coding agent. That minimalism is intentional — it ships as a blank canvas and lets the community build on top of it. The result is a rich ecosystem of packages: skills, themes, MCP adapters, memory systems, prompt templates, sub-agents, cost trackers, and engineering frameworks.
     </p>
     <p>
       LazyPi is the fastest path into that ecosystem. Run one command and you get a curated selection of the community's best work, pre-configured and ready to use. No research, no manual installs, no configuration tax.
@@ -76,7 +78,7 @@
     </p>
 
     <h2>What it installs</h2>
-    <p>LazyPi installs 23 hand-picked packages across five categories:</p>
+    <p>LazyPi installs 24 hand-picked packages across five categories:</p>
 
     <table>
       <thead>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -50,6 +50,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -85,7 +87,7 @@
 
     <h2>Install all vs. interactive picker</h2>
     <p>
-      Choosing <strong>Install all (recommended)</strong> installs all 23 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
+      Choosing <strong>Install all (recommended)</strong> installs all 24 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
     </p>
     <p>
       The interactive picker lets you browse the catalog and select only what you want. Use arrow keys to navigate, space to toggle, and enter to confirm.

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -48,6 +48,7 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link active">Add Directory</a>
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -113,9 +114,9 @@
         <span class="prev-next-label">Previous</span>
         ← Simplify
       </a>
-      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
+      <a href="/docs/packages/prompt-templates.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Powerbar →
+        Prompt Templates →
       </a>
     </nav>
 

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/diff-review.html
+++ b/docs/docs/packages/diff-review.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Packages — LazyPi Docs</title>
-  <meta name="description" content="All 23 packages included in LazyPi.">
+  <meta name="description" content="All 24 packages included in LazyPi.">
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -50,6 +50,7 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -62,7 +63,7 @@
 
   <main class="docs-content">
     <h1>Packages</h1>
-    <p class="page-desc">23 hand-picked packages from the Pi community. Install all of them or pick exactly what you want.</p>
+    <p class="page-desc">24 hand-picked packages from the Pi community. Install all of them or pick exactly what you want.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">
@@ -104,6 +105,11 @@
         <span class="pkg-tag core">core</span>
         <div class="pkg-name">Add Directory</div>
         <div class="pkg-desc">Load context from directories outside your working directory into a Pi session</div>
+      </a>
+      <a class="pkg-card" href="/docs/packages/prompt-templates.html">
+        <span class="pkg-tag core">core</span>
+        <div class="pkg-name">Prompt Templates</div>
+        <div class="pkg-desc">Add model, skill, and thinking frontmatter so prompt templates switch modes automatically</div>
       </a>
       <a class="pkg-card" href="/docs/packages/powerbar.html">
         <span class="pkg-tag ui">ui</span>

--- a/docs/docs/packages/mcp-adapter.html
+++ b/docs/docs/packages/mcp-adapter.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/plan.html
+++ b/docs/docs/packages/plan.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link active">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -48,6 +48,7 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link active">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -83,9 +84,9 @@
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/add-dir.html" class="prev-next-link">
+      <a href="/docs/packages/prompt-templates.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Add Directory
+        ← Prompt Templates
       </a>
       <a href="/docs/packages/usage.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Memory — LazyPi Docs</title>
+  <title>Prompt Templates — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -43,13 +43,12 @@
       <a href="/docs/packages/subagents.html" class="sidebar-link">Sub-agents</a>
       <a href="/docs/packages/mcp-adapter.html" class="sidebar-link">MCP Adapter</a>
       <a href="/docs/packages/web-access.html" class="sidebar-link">Web Access</a>
-      <a href="/docs/packages/memory.html" class="sidebar-link active">Memory</a>
+      <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
-      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link active">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -61,59 +60,53 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Memory</h1>
-    <p class="page-desc">Persistent Git-backed Markdown memory that survives session resets and context compaction.</p>
+    <h1>Prompt Templates</h1>
+    <p class="page-desc">Add model, skill, and thinking frontmatter to Pi prompt templates so slash commands switch modes automatically.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-memory-md gives Pi a durable external memory store backed by a GitHub repository. At session start, it syncs the memory repo, builds an index of what's stored, and injects a summary into the system prompt. Pi can then read and write individual memory files on demand throughout the session.
+      Pi-prompt-template-model extends Pi's built-in prompt templates with frontmatter like <code>model</code>, <code>skill</code>, and <code>thinking</code>. That lets a template become a reusable agent mode: run a single slash command and Pi can switch to the right model, preload a skill, adjust thinking depth, and restore your previous session settings when the task finishes.
     </p>
     <p>
-      Memory is stored as plain Markdown files — human-readable and fully version-controlled. Because it's Git-backed, the full history of what Pi has learned is auditable and reversible. Memories persist across sessions, context resets, and machine switches.
+      The extension also supports more advanced template workflows like fallback model lists, chain templates, looping, and optional delegated execution through sub-agents. You still author normal prompt templates — this package just makes them much more powerful.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Without persistent memory, every Pi session starts from zero. Pi can't remember how your project is structured, what decisions were made, what approaches failed, or what your preferences are. Memory makes Pi genuinely smarter the longer you use it — it compounds knowledge rather than discarding it.
+      One of the easiest ways to make Pi feel personal is to create task-specific slash commands. Prompt Templates turns those commands into reliable workflows instead of fragile text snippets. You can make a <code>/deep-debug</code> template that always uses a stronger model, a <code>/quick-fix</code> template that stays cheap and fast, or a review template that injects exactly the right skill every time.
+    </p>
+    <p>
+      It fits LazyPi's philosophy well: remove repetitive setup, make good workflows easy, and let users keep the speed of Pi's minimal interface while gaining much richer behavior underneath.
     </p>
 
-    <h2>Commands</h2>
-    <table>
-      <thead>
-        <tr><th>Command</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>/memory-init</code></td>
-          <td>Clone the memory repo, create the directory structure, and generate default files</td>
-        </tr>
-        <tr>
-          <td><code>/memory-status</code></td>
-          <td>Show memory repo status: project name, git status, and local path</td>
-        </tr>
-        <tr>
-          <td><code>/memory-refresh</code></td>
-          <td>Rebuild the memory cache and inject the updated index into the current session</td>
-        </tr>
-        <tr>
-          <td><code>/memory-check</code></td>
-          <td>Display the directory tree of the memory folder</td>
-        </tr>
-      </tbody>
-    </table>
+    <h2>Usage notes</h2>
+    <p>After installation, restart Pi so the extension loads. Then add frontmatter to one of your prompt templates:</p>
+    <pre><code>---
+description: Debug Python in tmux REPL
+model: claude-sonnet-4-20250514
+skill: tmux
+thinking: medium
+---
+Start a Python REPL session and help me debug: $@</code></pre>
+    <p>
+      When you run that template's slash command, Pi switches to the requested model, loads the skill context, and applies the chosen thinking level for the duration of the task. By default it restores your previous session settings when the command completes.
+    </p>
+    <p>
+      If you use delegated execution features like <code>subagent</code> or <code>inheritContext</code>, LazyPi already installs <a href="/docs/packages/subagents.html">Sub-agents</a> for you — so those workflows are available out of the box.
+    </p>
 
     <div class="learn-more">
-      <a href="https://github.com/VandeeFeng/pi-memory-md" target="_blank" rel="noopener">→ GitHub — VandeeFeng/pi-memory-md</a>
+      <a href="https://github.com/nicobailon/pi-prompt-template-model" target="_blank" rel="noopener">→ GitHub — nicobailon/pi-prompt-template-model</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/web-access.html" class="prev-next-link">
+      <a href="/docs/packages/add-dir.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Web Access
+        ← Add Directory
       </a>
-      <a href="/docs/packages/diff-review.html" class="prev-next-link next">
+      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Diff Review →
+        Powerbar →
       </a>
     </nav>
 

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/simplify.html
+++ b/docs/docs/packages/simplify.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link active">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link active">Todo List</a>

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link active">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -48,6 +48,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -50,6 +50,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -50,6 +50,8 @@
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
+
+      <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robzolkos/lazypi",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robzolkos/lazypi",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robzolkos/lazypi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Opinionated one-shot installer for a full-featured Pi coding agent setup.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Add `pi-prompt-template-model` to LazyPi so users get prompt-template model switching out of the box, along with docs and CI coverage to keep the catalog and documentation in sync.

- add the package to the default LazyPi catalog as `prompt-templates`
- document the package with a dedicated docs page and package index entry
- update docs navigation and package counts from 23 to 24
- extend CI expectations to include the new installed package
