### PR TITLE
Filter duplicate pi-themes entries and document LazyPi theme sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ That's it.  Once done - run `pi` and experience a feature rich coding agent expe
 
 Install is **idempotent** — LazyPi reads your Pi settings and skips any package that is already installed, so re-running is safe.
 
+For theme packages, LazyPi also applies a small Pi package filter so duplicate theme IDs do not collide. It keeps both `pi-themes` and `@victor-software-house/pi-curated-themes` installed, but excludes `catppuccin-mocha` and `gruvbox-dark` from `pi-themes` so those two come from the curated themes package.
+
 ## Commands
 
 | Command | What it does |

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -227,6 +227,15 @@ function settingsPath(local) {
 // so they fall back to the user's active session model instead.
 const SUBAGENT_BUILTIN_MODELS = ["context-builder", "planner", "researcher", "reviewer", "scout", "worker"];
 
+const PI_THEMES_FILTERED_ENTRY = {
+	source: "npm:pi-themes",
+	themes: [
+		"themes/*.json",
+		"!themes/catppuccin-mocha.json",
+		"!themes/gruvbox-dark.json",
+	],
+};
+
 function readSettings(local) {
 	const path = settingsPath(local);
 	if (!existsSync(path)) return { path, exists: false, parsed: null, error: null };
@@ -242,13 +251,12 @@ function backupPath(path) {
 	return `${path}.lazypi.${timestamp}.bak`;
 }
 
-function writeSubagentOverrides(local) {
+function writeSettings(local, mutate) {
 	const current = readSettings(local);
 	if (current.error) return { ok: false, path: current.path, error: current.error };
 	const settings = current.parsed ?? {};
-	const overrides = {};
-	for (const name of SUBAGENT_BUILTIN_MODELS) overrides[name] = { model: "" };
-	settings.subagents = { ...(settings.subagents ?? {}), agentOverrides: { ...(settings.subagents?.agentOverrides ?? {}), ...overrides } };
+	const changed = mutate(settings);
+	if (!changed) return { ok: true, path: current.path, backup: null, changed: false };
 	mkdirSync(dirname(current.path), { recursive: true });
 	let backup = null;
 	if (current.exists) {
@@ -256,7 +264,32 @@ function writeSubagentOverrides(local) {
 		copyFileSync(current.path, backup);
 	}
 	writeFileSync(current.path, JSON.stringify(settings, null, 2) + "\n", "utf8");
-	return { ok: true, path: current.path, backup };
+	return { ok: true, path: current.path, backup, changed: true };
+}
+
+function writeSubagentOverrides(local) {
+	return writeSettings(local, (settings) => {
+		const overrides = {};
+		for (const name of SUBAGENT_BUILTIN_MODELS) overrides[name] = { model: "" };
+		settings.subagents = { ...(settings.subagents ?? {}), agentOverrides: { ...(settings.subagents?.agentOverrides ?? {}), ...overrides } };
+		return true;
+	});
+}
+
+function writePiThemesFilter(local) {
+	return writeSettings(local, (settings) => {
+		const packages = Array.isArray(settings.packages) ? [...settings.packages] : [];
+		const index = packages.findIndex((entry) => (typeof entry === "string" && entry === PI_THEMES_FILTERED_ENTRY.source)
+			|| (entry && typeof entry === "object" && entry.source === PI_THEMES_FILTERED_ENTRY.source));
+		if (index === -1) return false;
+		const entry = packages[index];
+		if (entry && typeof entry === "object" && Array.isArray(entry.themes)) return false;
+		packages[index] = entry && typeof entry === "object"
+			? { ...entry, themes: [...PI_THEMES_FILTERED_ENTRY.themes] }
+			: { ...PI_THEMES_FILTERED_ENTRY, themes: [...PI_THEMES_FILTERED_ENTRY.themes] };
+		settings.packages = packages;
+		return true;
+	});
 }
 
 function readInstalledSources(local) {
@@ -526,7 +559,21 @@ async function cmdInstall(flags) {
 		}
 	}
 
+
 	if (toInstall.length === 0) {
+		if (selected.some((p) => p.id === "pi-themes")) {
+			const themesFilterResult = writePiThemesFilter(flags.local);
+			if (!themesFilterResult.ok) {
+				const message = `Refusing to update ${themesFilterResult.path} because it is not valid JSON (${themesFilterResult.error}). Fix the file first, then rerun lazypi.`;
+				if (interactive) {
+					log.error(message);
+					outro(red("Aborted."));
+				} else {
+					console.error(red(message));
+				}
+				return 2;
+			}
+		}
 		printCheatsheet(selected, interactive);
 		const done = "Nothing to do — every selected package is already installed.";
 		if (interactive) log.success(green(done));
@@ -555,6 +602,20 @@ async function cmdInstall(flags) {
 			failed.push(pkg);
 			if (interactive) log.error(`failed to install ${pkg.id}`);
 			else console.error(red(`  ✗ failed to install ${pkg.id}`));
+		}
+	}
+
+	if (selected.some((p) => p.id === "pi-themes")) {
+		const themesFilterResult = writePiThemesFilter(flags.local);
+		if (!themesFilterResult.ok) {
+			const message = `Refusing to update ${themesFilterResult.path} because it is not valid JSON (${themesFilterResult.error}). Fix the file first, then rerun lazypi.`;
+			if (interactive) {
+				log.error(message);
+				outro(red("Aborted."));
+			} else {
+				console.error(red(message));
+			}
+			return 2;
 		}
 	}
 

--- a/docs/themes.html
+++ b/docs/themes.html
@@ -212,7 +212,7 @@
 <div class="header">
   <p class="header-eyebrow">Installed with LazyPi</p>
   <h1>76 Themes</h1>
-  <p>Every theme you get with <code style="color:var(--green)">npx @robzolkos/lazypi</code> — click any tile to preview.</p>
+  <p>Every theme you get with <code style="color:var(--green)">npx @robzolkos/lazypi</code> — click any tile to preview. LazyPi filters duplicate theme IDs from <code style="color:var(--green)">pi-themes</code>, so <code style="color:var(--green)">catppuccin-mocha</code> and <code style="color:var(--green)">gruvbox-dark</code> are sourced from <code style="color:var(--green)">pi-curated-themes</code>.</p>
 </div>
 
 <div class="filter-bar" id="filter-bar"></div>
@@ -248,7 +248,7 @@ const themes = [
   { name: "Brogrammer",              pkg: "pi-curated-themes", bg: "#131313", fg: "#d6dbe5", swatches: ["#f81118","#2dc55e","#ecba0f","#2a84d2","#4e5ab7","#1081d6"] },
   { name: "Carbonfox",               pkg: "pi-curated-themes", bg: "#161616", fg: "#f2f4f8", swatches: ["#ee5396","#25be6a","#08bdba","#78a9ff","#be95ff","#33b1ff"] },
   { name: "Catppuccin Latte",        pkg: "pi-themes",         bg: "#eff1f5", fg: "#4c4f69", swatches: ["#d20f39","#40a02b","#df8e1d","#1e66f5","#8839ef","#04a5e5"] },
-  { name: "Catppuccin Mocha",        pkg: "pi-themes",         bg: "#1e1e2e", fg: "#cdd6f4", swatches: ["#f38ba8","#a6e3a1","#f9e2af","#89b4fa","#cba6f7","#89dceb"] },
+  { name: "Catppuccin Mocha",        pkg: "pi-curated-themes", bg: "#1e1e2e", fg: "#cdd6f4", swatches: ["#f38ba8","#a6e3a1","#f9e2af","#89b4fa","#cba6f7","#89dceb"] },
   { name: "Citruszest",              pkg: "pi-curated-themes", bg: "#121212", fg: "#bfbfbf", swatches: ["#ff5454","#00cc7a","#ffd400","#00bfff","#ff90fe","#48d1cc"] },
   { name: "Cursor Dark",             pkg: "pi-curated-themes", bg: "#141414", fg: "#d4d4d4", swatches: ["#fc6b83","#3fa266","#d2943e","#81a1c1","#b48ead","#88c0d0"] },
   { name: "Cutie Pro",               pkg: "pi-curated-themes", bg: "#181818", fg: "#d5d0c9", swatches: ["#f56e7f","#bec975","#f58669","#42d9c5","#d286b7","#37cb8a"] },
@@ -271,7 +271,7 @@ const themes = [
   { name: "GitHub Dark High Contrast", pkg: "pi-curated-themes", bg: "#0a0c10", fg: "#f0f3f6", swatches: ["#ff9492","#26cd4d","#f0b72f","#71b7ff","#cb9eff","#39c5cf"] },
   { name: "Glacier",                 pkg: "pi-curated-themes", bg: "#0c1115", fg: "#ffffff", swatches: ["#bd0f2f","#35a770","#fb9435","#1f5872","#bd2523","#778397"] },
   { name: "Gruber Darker",           pkg: "pi-curated-themes", bg: "#181818", fg: "#e4e4e4", swatches: ["#ff0a36","#42dc00","#ffdb00","#92a7cb","#a095cb","#90aa9e"] },
-  { name: "Gruvbox Dark",            pkg: "pi-themes",         bg: "#282828", fg: "#ebdbb2", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
+  { name: "Gruvbox Dark",            pkg: "pi-curated-themes", bg: "#282828", fg: "#ebdbb2", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
   { name: "Gruvbox Dark Hard",       pkg: "pi-curated-themes", bg: "#1d2021", fg: "#ebdbb2", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
   { name: "Gruvbox Light",           pkg: "pi-themes",         bg: "#fbf1c7", fg: "#3c3836", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
   { name: "Gruvbox Material",        pkg: "pi-curated-themes", bg: "#1d2021", fg: "#d4be98", swatches: ["#ea6926","#c1d041","#eecf75","#6da3ec","#fd9bc1","#fe9d6e"] },


### PR DESCRIPTION
## Summary

LazyPi installs both `pi-themes` and `@victor-software-house/pi-curated-themes`, which causes duplicate theme IDs for:

- `catppuccin-mocha`
- `gruvbox-dark`

This change makes LazyPi rewrite the `pi-themes` package entry in Pi settings to exclude those two themes, avoiding conflict warnings while keeping both packages installed.

## Changes

- update `bin/lazypi.mjs` to apply a Pi package filter for `pi-themes`
- exclude:
  - `themes/catppuccin-mocha.json`
  - `themes/gruvbox-dark.json`
- apply the filter both:
  - after fresh installs
  - on reruns when `pi-themes` is already installed
- leave existing custom `themes` filters alone
- update `README.md` to document the duplicate-theme filtering behavior
- update `docs/themes.html` so `Catppuccin Mocha` and `Gruvbox Dark` are labeled from their effective LazyPi source: `pi-curated-themes`

## Why

This makes LazyPi's default install behavior match what users actually see in Pi:

- no duplicate theme collisions for those two IDs
- both theme packages remain available
- docs accurately describe the effective source of installed themes

## Verification

- `node --check bin/lazypi.mjs`
- confirmed Pi settings filtering works for:
  - `catppuccin-mocha`
  - `gruvbox-dark`
- reviewed docs so theme sourcing matches LazyPi's effective installed result
