### PR TITLE
Add pi-interactive-shell to LazyPi catalog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
             "npm:@juanibiapina/pi-powerbar",
             "npm:@tmustier/pi-usage-extension",
             "npm:@tmustier/pi-raw-paste",
+            "npm:pi-interactive-shell",
             "npm:@tmustier/pi-ralph-wiggum",
             "npm:pi-btw",
             "npm:@every-env/compound-plugin",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ LazyPi will:
 1. Install `pi` for you if it isn't installed yet.
 2. Ask if you want to install all the packages or choose which to install.
 
+That setup includes agent tooling, memory, planning, interactive shell overlays for long-running CLIs, usage tracking, and themes.
+
 That's it.  Once done - run `pi` and experience a feature rich coding agent experience.
 
 Install is **idempotent** — LazyPi reads your Pi settings and skips any package that is already installed, so re-running is safe.

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -41,6 +41,7 @@ const PACKAGES = [
 	{ id: "raw-paste", category: "ui", source: "npm:@tmustier/pi-raw-paste", description: "Raw paste command", hint: "Paste raw clipboard content without Pi re-interpreting it." },
 	{ id: "todos", category: "ui", source: "git:github.com/tintinweb/pi-manage-todo-list@b75c449aa85ce328e9a8b632f62bf642aed40359", description: "Todo list management", hint: "Track multi-step work with live progress widget and session persistence." },
 	{ id: "btw", category: "ui", source: "npm:pi-btw", description: "Side-chat popover", hint: "Ask quick questions without polluting your conversation history." },
+	{ id: "interactive-shell", category: "ui", source: "npm:pi-interactive-shell", description: "Interactive shell overlays", hint: "Run Pi, Codex, editors, SSH, and long-running CLIs in observable overlays with hands-free and dispatch modes." },
 	{ id: "autoresearch", category: "research", source: "git:github.com/davebcn87/pi-autoresearch@5a29db080131449edc6d25a6b351b12879063366", description: "Autonomous experiment loop", hint: "Long-running autonomous research loop." },
 	{ id: "ralph-wiggum", category: "research", source: "npm:@tmustier/pi-ralph-wiggum", description: "Ralph Wiggum agent loop", hint: "Long-running iterative dev loops with goals, checklists, and optional self-reflection." },
 	{ id: "compound", category: "frameworks", source: "npm:@every-env/compound-plugin", description: "Compound Engineering workflow", hint: "Structured multi-step engineering workflow." },
@@ -197,7 +198,7 @@ ${bold("Default behaviour:")}
 
 ${bold("Categories:")}
   core         foundations: sub-agents, MCP, web access, memory, prompt templates, …
-  ui           powerbar, usage dashboard, plan-notator, …
+  ui           powerbar, interactive shell overlays, usage dashboard, …
   research     autonomous research / experiment loops
   frameworks   structured engineering workflows
 

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -56,6 +56,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -56,6 +56,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -78,7 +79,7 @@
     </p>
 
     <h2>What it installs</h2>
-    <p>LazyPi installs 24 hand-picked packages across five categories:</p>
+    <p>LazyPi installs 25 hand-picked packages across five categories:</p>
 
     <table>
       <thead>
@@ -103,6 +104,10 @@
         <tr>
           <td>Sub-agents</td>
           <td>Parallel and chained sub-agent execution with 7 built-in specialists</td>
+        </tr>
+        <tr>
+          <td>Interactive CLIs</td>
+          <td>Observable overlays for Pi, Codex, Claude, SSH, editors, and long-running shell sessions</td>
         </tr>
         <tr>
           <td>Memory</td>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -56,6 +56,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -87,7 +88,7 @@
 
     <h2>Install all vs. interactive picker</h2>
     <p>
-      Choosing <strong>Install all (recommended)</strong> installs all 24 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
+      Choosing <strong>Install all (recommended)</strong> installs all 25 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
     </p>
     <p>
       The interactive picker lets you browse the catalog and select only what you want. Use arrow keys to navigate, space to toggle, and enter to confirm.

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -53,6 +53,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link active">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -118,9 +119,9 @@
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/btw.html" class="prev-next-link">
+      <a href="/docs/packages/interactive-shell.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← BTW
+        ← Interactive Shell
       </a>
       <a href="/docs/packages/ralph-wiggum.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link active">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -130,9 +131,9 @@
         <span class="prev-next-label">Previous</span>
         ← Todo List
       </a>
-      <a href="/docs/packages/autoresearch.html" class="prev-next-link next">
+      <a href="/docs/packages/interactive-shell.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Autoresearch →
+        Interactive Shell →
       </a>
     </nav>
 

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link active">Compound Engineering</a>

--- a/docs/docs/packages/diff-review.html
+++ b/docs/docs/packages/diff-review.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Packages — LazyPi Docs</title>
-  <meta name="description" content="All 24 packages included in LazyPi.">
+  <meta name="description" content="All 25 packages included in LazyPi.">
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -55,6 +55,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -63,7 +64,7 @@
 
   <main class="docs-content">
     <h1>Packages</h1>
-    <p class="page-desc">24 hand-picked packages from the Pi community. Install all of them or pick exactly what you want.</p>
+    <p class="page-desc">25 hand-picked packages from the Pi community. Install all of them or pick exactly what you want.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">
@@ -130,6 +131,11 @@
         <span class="pkg-tag ui">ui</span>
         <div class="pkg-name">BTW</div>
         <div class="pkg-desc">Side conversation channel running a full Pi sub-session in a modal overlay</div>
+      </a>
+      <a class="pkg-card" href="/docs/packages/interactive-shell.html">
+        <span class="pkg-tag ui">ui</span>
+        <div class="pkg-name">Interactive Shell</div>
+        <div class="pkg-desc">Observable overlays for Pi, Codex, Claude, SSH, editors, and long-running terminal sessions</div>
       </a>
       <a class="pkg-card" href="/docs/packages/autoresearch.html">
         <span class="pkg-tag research">research</span>

--- a/docs/docs/packages/interactive-shell.html
+++ b/docs/docs/packages/interactive-shell.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Simplify — LazyPi Docs</title>
+  <title>Interactive Shell — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -46,15 +46,14 @@
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
-      <a href="/docs/packages/simplify.html" class="sidebar-link active">Simplify</a>
+      <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
-      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link active">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>
@@ -62,20 +61,23 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Simplify</h1>
-    <p class="page-desc">Reviews recently changed code for clarity, consistency, and maintainability — never changes behavior.</p>
+    <h1>Interactive Shell</h1>
+    <p class="page-desc">Observable terminal overlays for Pi and other CLIs, with interactive, hands-free, and dispatch workflows.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-simplify reads every file that changed in your working tree, applies clarity and consistency improvements one at a time, then runs your test suite after each change to verify nothing broke. It operates on a strict constraint: it may only improve how the code reads, never what it does.
+      Pi Interactive Shell gives Pi a real terminal overlay for interactive command-line programs. Instead of guessing at TUI output, Pi can launch and supervise Pi itself, Codex, Claude, editors, REPLs, SSH sessions, database shells, dev servers, and other long-running terminal workflows while you watch.
     </p>
     <p>
-      This means simplify is safe to run after any implementation pass. It won't introduce regressions because it won't change logic. What it will do is catch naming inconsistencies, overly complex expressions, unnecessary nesting, and other readability issues that are easy to miss when you're focused on getting the feature to work.
+      It supports three main ways of working: <strong>interactive</strong> for direct control, <strong>hands-free</strong> for monitored long-running sessions, and <strong>dispatch</strong> for fire-and-forget delegation that wakes Pi up when the session finishes. Background sessions can be reattached later, and the package also ships prompt templates and skills for agent-driven review and implementation workflows.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Implementation and cleanup are cognitively different tasks. Trying to do both at once usually means the cleanup doesn't happen. Simplify makes it a one-command step after implementation — run it, review the diff, and you're done.
+      A lot of real developer tools are still terminal-first: editors like <code>vim</code>, SSH, watch mode test runners, database shells, long-running build processes, and other agent CLIs. Interactive Shell lets Pi work with those tools in a visible, controllable way instead of treating them as opaque subprocesses.
+    </p>
+    <p>
+      That makes it a strong fit for LazyPi: it expands what Pi can safely supervise without forcing you to leave the terminal. Upstream ships prebuilt PTY binaries via <code>zigpty</code>, so supported platforms do not need a native <code>node-gyp</code> toolchain just to install it.
     </p>
 
     <h2>Commands</h2>
@@ -85,36 +87,44 @@
       </thead>
       <tbody>
         <tr>
-          <td><code>/simplify</code></td>
-          <td>Review all uncommitted changes</td>
+          <td><code>/spawn [agent] [prompt]</code></td>
+          <td>Launch Pi, Claude, Codex, or another configured agent in an interactive overlay</td>
         </tr>
         <tr>
-          <td><code>/simplify --staged</code></td>
-          <td>Review only staged changes</td>
+          <td><code>/spawn [agent] "prompt" --hands-free</code></td>
+          <td>Start a monitored session that Pi can check in on while you watch</td>
         </tr>
         <tr>
-          <td><code>/simplify src/foo.ts src/bar.ts</code></td>
-          <td>Review specific files</td>
+          <td><code>/spawn [agent] "prompt" --dispatch</code></td>
+          <td>Delegate work and wake Pi up when the session finishes</td>
         </tr>
         <tr>
-          <td><code>/simplify --ref=main</code></td>
-          <td>Diff against a specific branch and review those changes</td>
+          <td><code>/attach [session-id]</code></td>
+          <td>Reconnect to a background or previously launched session</td>
+        </tr>
+        <tr>
+          <td><code>/dismiss [session-id]</code></td>
+          <td>Clean up a background session you no longer need</td>
         </tr>
       </tbody>
     </table>
 
+    <p>
+      You can also simply ask Pi in natural language to run something in dispatch or hands-free mode. The package exposes an <code>interactive_shell</code> tool under the hood, but end users normally work through slash commands or plain-English requests.
+    </p>
+
     <div class="learn-more">
-      <a href="https://github.com/MattDevy/pi-extensions" target="_blank" rel="noopener">→ GitHub — MattDevy/pi-extensions</a>
+      <a href="https://github.com/nicobailon/pi-interactive-shell" target="_blank" rel="noopener">→ GitHub — nicobailon/pi-interactive-shell</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/plan.html" class="prev-next-link">
+      <a href="/docs/packages/btw.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Plan
+        ← BTW
       </a>
-      <a href="/docs/packages/add-dir.html" class="prev-next-link next">
+      <a href="/docs/packages/autoresearch.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Add Directory →
+        Autoresearch →
       </a>
     </nav>
 

--- a/docs/docs/packages/mcp-adapter.html
+++ b/docs/docs/packages/mcp-adapter.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/memory.html
+++ b/docs/docs/packages/memory.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/plan.html
+++ b/docs/docs/packages/plan.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -53,6 +53,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -53,6 +53,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link active">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link active">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link active">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -54,6 +54,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -56,6 +56,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -56,6 +56,7 @@
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
+      <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
       <a href="/docs/packages/autoresearch.html" class="sidebar-link">Autoresearch</a>
       <a href="/docs/packages/ralph-wiggum.html" class="sidebar-link">Ralph Wiggum</a>
       <a href="/docs/packages/compound-engineering.html" class="sidebar-link">Compound Engineering</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -776,6 +776,12 @@
         <div class="catalog-desc">Ask quick side questions without polluting history</div>
         <div class="catalog-author">by dbachelder</div>
       </a>
+      <a class="catalog-card" href="https://github.com/nicobailon/pi-interactive-shell" target="_blank" rel="noopener">
+        <span class="catalog-tag ui">ui</span>
+        <div class="catalog-name">pi-interactive-shell</div>
+        <div class="catalog-desc">Observable interactive shell overlays with hands-free and dispatch modes</div>
+        <div class="catalog-author">by nicobailon</div>
+      </a>
       <a class="catalog-card" href="https://github.com/davebcn87/pi-autoresearch" target="_blank" rel="noopener">
         <span class="catalog-tag research">research</span>
         <div class="catalog-name">pi-autoresearch</div>


### PR DESCRIPTION
## Summary
- add `pi-interactive-shell` to the default LazyPi catalog
- add a dedicated package docs page and update package navigation
- update docs/package counts and CI expected installed packages

## Details
- chose `interactive-shell` as the LazyPi package id
- categorized it under `ui`
- used source `npm:pi-interactive-shell`
- no special install logic was needed

## Validation
- verified `bin/lazypi.mjs` syntax with `node --check`
- updated `.github/workflows/test.yml` expected package list
- updated duplicated docs sidebars and package index links
