### PR TITLE
Improve mobile docs navigation

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -73,6 +73,72 @@ body {
 }
 .nav-cta:hover { opacity: 0.85; }
 
+.mobile-nav {
+  display: none;
+  position: relative;
+  margin-left: auto;
+}
+.mobile-nav summary {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.2rem;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 1.8rem;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+}
+.mobile-nav summary::-webkit-details-marker { display: none; }
+.mobile-nav summary:hover { color: var(--text-bright); }
+.mobile-nav summary:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+.mobile-nav[open] summary { color: var(--green); }
+.mobile-nav-menu {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: min(260px, calc(100vw - 2rem));
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: rgba(10,10,10,0.97);
+  box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+}
+.mobile-nav-menu a {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+}
+.mobile-nav-menu a:hover, .mobile-nav-menu a.active {
+  color: var(--green);
+  background: var(--bg2);
+}
+.mobile-nav-menu .nav-cta {
+  display: block;
+  margin-top: 0.35rem;
+  text-align: center;
+  color: #000;
+  padding: 0.6rem 0.9rem;
+}
+.mobile-nav-menu a svg { display: block; }
+
 /* DOCS SHELL */
 .docs-shell {
   display: flex;
@@ -127,15 +193,17 @@ body {
 .sidebar-toggle {
   display: none;
   position: fixed;
-  top: 16px;
+  top: 14px;
   right: 1rem;
   z-index: 200;
-  background: none;
+  background: var(--bg2);
   border: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 1rem;
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 700;
   cursor: pointer;
-  padding: 0.3rem 0.6rem;
+  padding: 0.45rem 0.75rem;
   border-radius: 3px;
   line-height: 1;
 }
@@ -381,6 +449,9 @@ body {
 
 /* MOBILE */
 @media (max-width: 768px) {
+  .site-nav { padding: 0 1rem; }
+  .nav-links-desktop, .nav-cta-desktop { display: none; }
+  .mobile-nav { display: block; }
   .sidebar {
     transform: translateX(-100%);
     transition: transform 0.25s ease;
@@ -388,8 +459,7 @@ body {
   }
   .sidebar.open { transform: translateX(0); }
   .docs-content { margin-left: 0; padding: 2rem 1.25rem 5rem; }
-  .sidebar-toggle { display: block; }
-  .nav-links { display: none; }
+  .sidebar-toggle { display: block; right: 5.5rem; }
 }
 
 /* FOOTER */

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/diff-review.html
+++ b/docs/docs/packages/diff-review.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/mcp-adapter.html
+++ b/docs/docs/packages/mcp-adapter.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/memory.html
+++ b/docs/docs/packages/memory.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/plan.html
+++ b/docs/docs/packages/plan.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/simplify.html
+++ b/docs/docs/packages/simplify.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -11,20 +11,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -12,20 +12,34 @@
 
 <nav class="site-nav">
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
-    <a href="/#features">Features</a>
-    <a href="/#catalog">Catalog</a>
-    <a href="/themes.html">Themes</a>
-    <a href="/docs/" class="active">Docs</a>
-    <a href="/faq.html">FAQ</a>
-    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+  <div class="nav-links nav-links-desktop">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-    </a>
+      </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+      <a href="/#features">Features</a>
+      <a href="/#catalog">Catalog</a>
+      <a href="/themes.html">Themes</a>
+      <a href="/docs/" class="active">Docs</a>
+      <a href="/faq.html">FAQ</a>
+      <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
-<button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+<button class="sidebar-toggle" id="sidebar-toggle" type="button" onclick="toggleSidebar()" aria-label="Toggle docs navigation">Docs</button>
 
 <div class="docs-shell">
   <aside class="sidebar" id="sidebar">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -71,6 +71,72 @@
     }
     .nav-cta:hover { opacity: 0.85; }
 
+    .mobile-nav {
+      display: none;
+      position: relative;
+      margin-left: auto;
+    }
+    .mobile-nav summary {
+      list-style: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.1rem 0.2rem;
+      border: none;
+      background: transparent;
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 1.8rem;
+      font-weight: 400;
+      line-height: 1;
+      cursor: pointer;
+    }
+    .mobile-nav summary::-webkit-details-marker { display: none; }
+    .mobile-nav summary:hover { color: var(--text-bright); }
+    .mobile-nav summary:focus-visible {
+      outline: 2px solid var(--green);
+      outline-offset: 4px;
+      border-radius: 4px;
+    }
+    .mobile-nav[open] summary { color: var(--green); }
+    .mobile-nav-menu {
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      right: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      width: min(260px, calc(100vw - 2rem));
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: rgba(10,10,10,0.97);
+      box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+    }
+    .mobile-nav-menu a {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-dim);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.45rem 0.5rem;
+      border-radius: 3px;
+      transition: color 0.2s, background 0.2s;
+    }
+    .mobile-nav-menu a:hover, .mobile-nav-menu a.active {
+      color: var(--green);
+      background: var(--bg2);
+    }
+    .mobile-nav-menu .nav-cta {
+      display: block;
+      margin-top: 0.35rem;
+      text-align: center;
+      color: #000;
+      padding: 0.6rem 0.9rem;
+    }
+    .mobile-nav-menu a svg { display: block; }
+
     .header {
       padding: 8rem 2rem 3rem;
       text-align: center;
@@ -189,7 +255,9 @@
     footer a:hover { color: var(--green); }
 
     @media (max-width: 600px) {
-      .nav-links { display: none; }
+      nav { padding: 1rem; gap: 0.75rem; }
+      .nav-links-desktop, .nav-cta-desktop { display: none; }
+      .mobile-nav { display: block; }
     }
   </style>
 </head>
@@ -197,17 +265,31 @@
 
 <nav>
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
+  <div class="nav-links nav-links-desktop">
     <a href="/#features">Features</a>
     <a href="/#catalog">Catalog</a>
     <a href="/themes.html">Themes</a>
     <a href="/docs/">Docs</a>
     <a href="/faq.html" class="active">FAQ</a>
     <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
     </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+    <a href="/#features">Features</a>
+    <a href="/#catalog">Catalog</a>
+    <a href="/themes.html">Themes</a>
+    <a href="/docs/">Docs</a>
+    <a href="/faq.html" class="active">FAQ</a>
+    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
 <div class="header">

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,6 +90,72 @@
     }
     .nav-cta:hover { opacity: 0.85; }
 
+    .mobile-nav {
+      display: none;
+      position: relative;
+      margin-left: auto;
+    }
+    .mobile-nav summary {
+      list-style: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.1rem 0.2rem;
+      border: none;
+      background: transparent;
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 1.8rem;
+      font-weight: 400;
+      line-height: 1;
+      cursor: pointer;
+    }
+    .mobile-nav summary::-webkit-details-marker { display: none; }
+    .mobile-nav summary:hover { color: var(--text-bright); }
+    .mobile-nav summary:focus-visible {
+      outline: 2px solid var(--green);
+      outline-offset: 4px;
+      border-radius: 4px;
+    }
+    .mobile-nav[open] summary { color: var(--green); }
+    .mobile-nav-menu {
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      right: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      width: min(260px, calc(100vw - 2rem));
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: rgba(10,10,10,0.97);
+      box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+    }
+    .mobile-nav-menu a {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-dim);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.45rem 0.5rem;
+      border-radius: 3px;
+      transition: color 0.2s, background 0.2s;
+    }
+    .mobile-nav-menu a:hover, .mobile-nav-menu a.active {
+      color: var(--green);
+      background: var(--bg2);
+    }
+    .mobile-nav-menu .nav-cta {
+      display: block;
+      margin-top: 0.35rem;
+      text-align: center;
+      color: #000;
+      padding: 0.6rem 0.9rem;
+    }
+    .mobile-nav-menu a svg { display: block; }
+
     /* HERO */
     .hero {
       min-height: 100vh;
@@ -546,7 +612,9 @@
     footer a:hover { color: var(--green); }
 
     @media (max-width: 600px) {
-      .nav-links { display: none; }
+      nav { padding: 1rem; gap: 0.75rem; }
+      .nav-links-desktop, .nav-cta-desktop { display: none; }
+      .mobile-nav { display: block; }
       .stat { min-width: 50%; }
       .compare-table { font-size: 0.8rem; }
       .compare-table th, .compare-table td { padding: 0.65rem 0.75rem; }
@@ -557,17 +625,31 @@
 
 <nav>
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
+  <div class="nav-links nav-links-desktop">
     <a href="/#features">Features</a>
     <a href="/#catalog">Catalog</a>
     <a href="/themes.html">Themes</a>
     <a href="/docs/">Docs</a>
     <a href="/faq.html">FAQ</a>
     <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
     </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+    <a href="/#features">Features</a>
+    <a href="/#catalog">Catalog</a>
+    <a href="/themes.html">Themes</a>
+    <a href="/docs/">Docs</a>
+    <a href="/faq.html">FAQ</a>
+    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
 <!-- HERO -->

--- a/docs/themes.html
+++ b/docs/themes.html
@@ -69,6 +69,72 @@
     }
     .nav-cta:hover { opacity: 0.85; }
 
+    .mobile-nav {
+      display: none;
+      position: relative;
+      margin-left: auto;
+    }
+    .mobile-nav summary {
+      list-style: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.1rem 0.2rem;
+      border: none;
+      background: transparent;
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 1.8rem;
+      font-weight: 400;
+      line-height: 1;
+      cursor: pointer;
+    }
+    .mobile-nav summary::-webkit-details-marker { display: none; }
+    .mobile-nav summary:hover { color: var(--text-bright); }
+    .mobile-nav summary:focus-visible {
+      outline: 2px solid var(--green);
+      outline-offset: 4px;
+      border-radius: 4px;
+    }
+    .mobile-nav[open] summary { color: var(--green); }
+    .mobile-nav-menu {
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      right: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      width: min(260px, calc(100vw - 2rem));
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: rgba(10,10,10,0.97);
+      box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+    }
+    .mobile-nav-menu a {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--text-dim);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.45rem 0.5rem;
+      border-radius: 3px;
+      transition: color 0.2s, background 0.2s;
+    }
+    .mobile-nav-menu a:hover, .mobile-nav-menu a.active {
+      color: var(--green);
+      background: var(--bg2);
+    }
+    .mobile-nav-menu .nav-cta {
+      display: block;
+      margin-top: 0.35rem;
+      text-align: center;
+      color: #000;
+      padding: 0.6rem 0.9rem;
+    }
+    .mobile-nav-menu a svg { display: block; }
+
     .header {
       padding: 8rem 2rem 3rem;
       text-align: center;
@@ -187,7 +253,9 @@
     footer a:hover { color: var(--green); }
 
     @media (max-width: 600px) {
-      .nav-links { display: none; }
+      nav { padding: 1rem; gap: 0.75rem; }
+      .nav-links-desktop, .nav-cta-desktop { display: none; }
+      .mobile-nav { display: block; }
       .themes-grid { grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); }
     }
   </style>
@@ -196,17 +264,31 @@
 
 <nav>
   <a class="nav-logo" href="/">Lazy<span>Pi</span></a>
-  <div class="nav-links">
+  <div class="nav-links nav-links-desktop">
     <a href="/#features">Features</a>
     <a href="/#catalog">Catalog</a>
     <a href="/themes.html" class="active">Themes</a>
     <a href="/docs/">Docs</a>
     <a href="/faq.html">FAQ</a>
     <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
     </a>
   </div>
-  <a class="nav-cta" href="/#install">Install</a>
+  <a class="nav-cta nav-cta-desktop" href="/#install">Install</a>
+  <details class="mobile-nav">
+    <summary aria-label="Toggle navigation">&#9776;</summary>
+    <div class="mobile-nav-menu">
+    <a href="/#features">Features</a>
+    <a href="/#catalog">Catalog</a>
+    <a href="/themes.html" class="active">Themes</a>
+    <a href="/docs/">Docs</a>
+    <a href="/faq.html">FAQ</a>
+    <a href="https://github.com/robzolkos/lazypi" target="_blank" rel="noopener" title="GitHub">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+    </a>
+      <a class="nav-cta" href="/#install">Install</a>
+    </div>
+  </details>
 </nav>
 
 <div class="header">

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "engines": {
     "node": ">=20"
   },
+  "scripts": {
+    "docs:serve": "node scripts/serve-docs.mjs"
+  },
   "dependencies": {
     "@clack/prompts": "^1.2.0"
   },

--- a/scripts/serve-docs.mjs
+++ b/scripts/serve-docs.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { dirname, extname, join, normalize, resolve } from 'node:path';
+import process from 'node:process';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const docsRoot = join(repoRoot, 'docs');
+
+const args = process.argv.slice(2);
+const portArgIndex = args.findIndex(arg => arg === '--port' || arg === '-p');
+const port = Number(
+  portArgIndex >= 0 && args[portArgIndex + 1]
+    ? args[portArgIndex + 1]
+    : process.env.PORT || 8000,
+);
+
+if (!Number.isInteger(port) || port <= 0) {
+  console.error('Invalid port. Use --port <number> or set PORT.');
+  process.exit(1);
+}
+
+const mimeTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webp': 'image/webp',
+};
+
+function getRequestPath(url = '/') {
+  const pathname = new URL(url, 'http://localhost').pathname;
+  return pathname === '/' ? '/index.html' : pathname;
+}
+
+function resolveFilePath(requestPath) {
+  const safePath = normalize(requestPath).replace(/^\/+/, '');
+  let filePath = join(docsRoot, safePath);
+
+  if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+    filePath = join(filePath, 'index.html');
+  }
+
+  if (!extname(filePath)) {
+    const htmlPath = `${filePath}.html`;
+    if (existsSync(htmlPath)) filePath = htmlPath;
+  }
+
+  return filePath;
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const requestPath = getRequestPath(req.url);
+    const filePath = resolveFilePath(requestPath);
+    const normalizedFilePath = resolve(filePath);
+
+    if (!normalizedFilePath.startsWith(docsRoot)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Forbidden');
+      return;
+    }
+
+    if (!existsSync(normalizedFilePath) || !statSync(normalizedFilePath).isFile()) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+      return;
+    }
+
+    const ext = extname(normalizedFilePath).toLowerCase();
+    res.writeHead(200, {
+      'Content-Type': mimeTypes[ext] || 'application/octet-stream',
+      'Cache-Control': 'no-cache',
+    });
+
+    createReadStream(normalizedFilePath).pipe(res);
+  } catch (error) {
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Server error');
+    console.error(error);
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Serving LazyPi docs at http://localhost:${port}`);
+  console.log('Routes:');
+  console.log(`  /            -> docs/index.html`);
+  console.log(`  /docs/       -> docs/docs/index.html`);
+  console.log(`  /themes.html -> docs/themes.html`);
+  console.log(`  /faq.html    -> docs/faq.html`);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
## Summary
- replace the hidden-on-mobile top nav with a `<details>/<summary>` mobile menu across the site and docs
- switch the mobile trigger to a larger hamburger icon and keep the docs sidebar toggle separate
- add `npm run docs:serve` with a small Node server for local docs preview

## Testing
- `git diff --check`
- `node scripts/serve-docs.mjs --port 8124`
- `curl -I http://localhost:8124/`
- `curl -I http://localhost:8124/docs/`