### PR TITLE
feat: add manual release-please npm publishing flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm with trusted publishing
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+name: release-please
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Please
+        id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          package-name: '@robzolkos/lazypi'

--- a/README.md
+++ b/README.md
@@ -68,31 +68,6 @@ LazyPi uses **Release Please** plus **npm trusted publishing**.
 6. Release Please creates the git tag and GitHub Release
 7. The `publish.yml` workflow publishes the tagged release to npm using trusted publishing
 
-### One-time npm setup
-
-In npm package settings for `@robzolkos/lazypi`, add a trusted publisher for this repo:
-
-- **Provider:** GitHub Actions
-- **Owner / repo:** `robzolkos/LazyPi`
-- **Workflow filename:** `publish.yml`
-
-No npm token is needed once trusted publishing is configured.
-
-### Commit message conventions
-
-Release Please determines the next version from commit messages. Recommended prefixes:
-
-- `fix:` → patch
-- `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` → major
-
-### Cut a release
-
-- Merge your normal work PRs into `master`
-- Run the `release-please` workflow from GitHub Actions when you want to cut a release
-- Review and merge the release PR it creates or updates
-- npm publish happens automatically after the GitHub Release is created
-
 ---
 
 For the full list of included packages and themes, see [lazypi.org](https://lazypi.org).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,45 @@ There is nothing to "uninstall" for LazyPi itself — `npx` doesn't leave it aro
 
 Run the built-in health check (`npx @robzolkos/lazypi doctor`).
 
+## Releasing
+
+LazyPi uses **Release Please** plus **npm trusted publishing**.
+
+### How it works
+
+1. You merge normal PRs into `master`
+2. You run the `release-please` workflow manually from GitHub Actions
+3. Release Please creates or updates a release PR
+4. That release PR bumps `package.json` and `package-lock.json` and can update `CHANGELOG.md`
+5. You merge the release PR through the normal protected-branch flow
+6. Release Please creates the git tag and GitHub Release
+7. The `publish.yml` workflow publishes the tagged release to npm using trusted publishing
+
+### One-time npm setup
+
+In npm package settings for `@robzolkos/lazypi`, add a trusted publisher for this repo:
+
+- **Provider:** GitHub Actions
+- **Owner / repo:** `robzolkos/LazyPi`
+- **Workflow filename:** `publish.yml`
+
+No npm token is needed once trusted publishing is configured.
+
+### Commit message conventions
+
+Release Please determines the next version from commit messages. Recommended prefixes:
+
+- `fix:` → patch
+- `feat:` → minor
+- `feat!:` or `BREAKING CHANGE:` → major
+
+### Cut a release
+
+- Merge your normal work PRs into `master`
+- Run the `release-please` workflow from GitHub Actions when you want to cut a release
+- Review and merge the release PR it creates or updates
+- npm publish happens automatically after the GitHub Release is created
+
 ---
 
 For the full list of included packages and themes, see [lazypi.org](https://lazypi.org).


### PR DESCRIPTION
## Summary
- add a manual Release Please workflow for creating release PRs
- add a publish workflow for npm trusted publishing from GitHub Releases
- document the new manual release flow in README

## Testing
- not run (workflow/documentation changes only)