### PR TITLE
docs: simplify release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ To release a new version:
 - Merge the Release Please release PR when you are ready to publish
 - GitHub creates the tag/release and publishes to npm automatically
 
-npm trusted publishing should be configured for:
-
-- **Provider:** GitHub Actions
-- **Repo:** `robzolkos/LazyPi`
-- **Workflow:** `release-please.yml`
-
 ---
 
 For the full list of included packages and themes, see [lazypi.org](https://lazypi.org).

--- a/README.md
+++ b/README.md
@@ -58,45 +58,19 @@ Run the built-in health check (`npx @robzolkos/lazypi doctor`).
 
 ## Releasing
 
-LazyPi uses **Release Please** plus **npm trusted publishing**.
+LazyPi uses **Release Please** and **npm trusted publishing**.
 
-### How it works
+To release a new version:
 
-1. Contributors merge normal PRs into `master`
-2. Release Please runs automatically on pushes to `master`
-3. It creates or updates a single release PR
-4. That release PR bumps `package.json` and `package-lock.json`
-5. When you merge the release PR, Release Please creates the git tag and GitHub Release
-6. The same workflow publishes that tagged release to npm using trusted publishing
+- Merge your normal PRs into `master`
+- Merge the Release Please release PR when you are ready to publish
+- GitHub creates the tag/release and publishes to npm automatically
 
-### One-time npm setup
-
-In npm package settings for `@robzolkos/lazypi`, add a trusted publisher for this repo:
+npm trusted publishing should be configured for:
 
 - **Provider:** GitHub Actions
-- **Owner / repo:** `robzolkos/LazyPi`
-- **Workflow filename:** `release-please.yml`
-
-No npm token is needed once trusted publishing is configured.
-
-### Commit message conventions
-
-Release Please determines the next version from commit messages. Recommended prefixes:
-
-- `fix:` → patch
-- `feat:` → minor
-- `feat!:` or `BREAKING CHANGE:` → major
-
-### Cut a release
-
-- Merge your normal work PRs into `master`
-- Wait for Release Please to open or update the release PR
-- When you want to publish, merge that release PR
-- Tag creation, GitHub Release creation, and npm publish happen automatically after that merge
-
-### Optional manual override
-
-If you ever need to force a specific version, you can still run the `release-please` workflow manually and provide `release_as`.
+- **Repo:** `robzolkos/LazyPi`
+- **Workflow:** `release-please.yml`
 
 ---
 


### PR DESCRIPTION
## Summary
- trim the release section in README down to the bare essentials
- keep only the required trusted publishing details

## Testing
- not run (docs only)