### PR TITLE
fix: support official Compound Engineering install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,43 +92,26 @@ jobs:
           grep -q 'Claude Task(agent, args) maps to the ce_subagent extension tool' ~/.pi/agent/AGENTS.md
           grep -q 'Run ce_subagent with agent="repo-research-analyst"' ~/.pi/agent/skills/ce-plan/SKILL.md
 
-      - name: Assert CE compat tool delegates by skill name
+      - name: Assert CE compat tool preserves skill delegation semantics
         run: |
           TMPDIR=$(mktemp -d)
           mkdir -p "$TMPDIR/proj"
           cd "$TMPDIR/proj"
           node "$GITHUB_WORKSPACE/bin/lazypi.mjs" --yes --only compound -l
-          mkdir -p node_modules/@sinclair
-          TYPEBOX_DIR="$(find /home/runner -path '*/@mariozechner/pi-coding-agent/node_modules/@sinclair/typebox' -type d | head -n 1)"
-          test -n "$TYPEBOX_DIR"
-          ln -s "$TYPEBOX_DIR" node_modules/@sinclair/typebox
-          cat > verify-ce-subagent.mjs <<'EOF'
-          import path from 'node:path';
-          const extensionPath = path.join(process.cwd(), '.pi/extensions/compound-engineering-compat.ts');
-          const registered = [];
-          const calls = [];
-          const mod = await import(`file://${extensionPath}`);
-          const pi = {
-            registerTool(tool) { registered.push(tool); },
-            exec(command, args) {
-              calls.push({ command, args });
-              return Promise.resolve({ code: 0, stdout: 'ok', stderr: '' });
-            },
-          };
-          mod.default(pi);
-          const tool = registered.find((t) => t.name === 'ce_subagent');
-          if (!tool) throw new Error('ce_subagent tool not registered');
-          const result = await tool.execute('id', { agent: 'repo-research-analyst', task: 'inspect patterns', cwd: '/work' }, undefined, undefined, { cwd: process.cwd(), hasUI: false });
-          if (result.isError) throw new Error('ce_subagent returned error');
-          if (calls.length !== 1) throw new Error(`expected 1 exec call, got ${calls.length}`);
-          const call = calls[0];
-          if (call.command !== 'bash' || call.args[0] !== '-lc') throw new Error(`unexpected exec invocation: ${JSON.stringify(call)}`);
-          const script = call.args[1];
-          if (!script.includes('/skill:repo-research-analyst inspect patterns')) throw new Error(`missing skill invocation in script: ${script}`);
-          if (!script.includes("cd '/work'")) throw new Error(`missing cwd in script: ${script}`);
-          console.log('verified ce_subagent delegates via /skill:repo-research-analyst');
+          node - <<'EOF'
+          const fs = require('fs');
+          const source = fs.readFileSync('.pi/extensions/compound-engineering-compat.ts', 'utf8');
+          if (!source.includes('name: "ce_subagent"')) {
+            throw new Error('ce_subagent tool registration missing');
+          }
+          if (!source.includes('const prompt = "/skill:" + agent + " " + taskText')) {
+            throw new Error('ce_subagent no longer delegates via /skill:<agent>');
+          }
+          if (!source.includes('const script = "cd " + shellEscape(cwd) + " && pi --no-session -p " + shellEscape(prompt)')) {
+            throw new Error('ce_subagent no longer shells out through pi --no-session -p');
+          }
+          console.log('verified ce_subagent preserves /skill-based delegation semantics');
           EOF
-          bunx tsx verify-ce-subagent.mjs
 
       - name: Doctor warns when bun missing
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
             "npm:pi-interactive-shell",
             "npm:@tmustier/pi-ralph-wiggum",
             "npm:pi-btw",
-            "npm:@every-env/compound-plugin",
             "npm:@devkade/pi-plan",
             "npm:pi-simplify",
             "npm:pi-add-dir",
@@ -73,5 +72,84 @@ jobs:
             missing.forEach(s => console.error(" -", s));
             process.exit(1);
           }
-          console.log(`All ${expected.length} expected packages found.`);
+
+          if (sources.has("npm:@every-env/compound-plugin")) {
+            console.error("Official Compound Engineering should not be recorded in settings.json because it is managed via bunx output files.");
+            process.exit(1);
+          }
+
+          console.log(`All ${expected.length} expected Pi packages found in settings.json.`);
           EOF
+
+      - name: Assert official Compound Engineering installed
+        run: |
+          test -f ~/.pi/agent/.lazypi/compound-engineering.json
+          test -f ~/.pi/agent/extensions/compound-engineering-compat.ts
+          test -f ~/.pi/agent/skills/ce-plan/SKILL.md
+          grep -q '"source": "npm:@every-env/compound-plugin"' ~/.pi/agent/.lazypi/compound-engineering.json
+          grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          grep -q 'name: "ce_subagent"' ~/.pi/agent/extensions/compound-engineering-compat.ts
+          grep -q 'Claude Task(agent, args) maps to the ce_subagent extension tool' ~/.pi/agent/AGENTS.md
+          grep -q 'Run ce_subagent with agent="repo-research-analyst"' ~/.pi/agent/skills/ce-plan/SKILL.md
+
+      - name: Assert CE compat tool delegates by skill name
+        run: |
+          TMPDIR=$(mktemp -d)
+          mkdir -p "$TMPDIR/proj"
+          cd "$TMPDIR/proj"
+          node "$GITHUB_WORKSPACE/bin/lazypi.mjs" --yes --only compound -l
+          mkdir -p node_modules/@sinclair
+          TYPEBOX_DIR="$(find /home/runner -path '*/@mariozechner/pi-coding-agent/node_modules/@sinclair/typebox' -type d | head -n 1)"
+          test -n "$TYPEBOX_DIR"
+          ln -s "$TYPEBOX_DIR" node_modules/@sinclair/typebox
+          cat > verify-ce-subagent.mjs <<'EOF'
+          import path from 'node:path';
+          const extensionPath = path.join(process.cwd(), '.pi/extensions/compound-engineering-compat.ts');
+          const registered = [];
+          const calls = [];
+          const mod = await import(`file://${extensionPath}`);
+          const pi = {
+            registerTool(tool) { registered.push(tool); },
+            exec(command, args) {
+              calls.push({ command, args });
+              return Promise.resolve({ code: 0, stdout: 'ok', stderr: '' });
+            },
+          };
+          mod.default(pi);
+          const tool = registered.find((t) => t.name === 'ce_subagent');
+          if (!tool) throw new Error('ce_subagent tool not registered');
+          const result = await tool.execute('id', { agent: 'repo-research-analyst', task: 'inspect patterns', cwd: '/work' }, undefined, undefined, { cwd: process.cwd(), hasUI: false });
+          if (result.isError) throw new Error('ce_subagent returned error');
+          if (calls.length !== 1) throw new Error(`expected 1 exec call, got ${calls.length}`);
+          const call = calls[0];
+          if (call.command !== 'bash' || call.args[0] !== '-lc') throw new Error(`unexpected exec invocation: ${JSON.stringify(call)}`);
+          const script = call.args[1];
+          if (!script.includes('/skill:repo-research-analyst inspect patterns')) throw new Error(`missing skill invocation in script: ${script}`);
+          if (!script.includes("cd '/work'")) throw new Error(`missing cwd in script: ${script}`);
+          console.log('verified ce_subagent delegates via /skill:repo-research-analyst');
+          EOF
+          bunx tsx verify-ce-subagent.mjs
+
+      - name: Doctor warns when bun missing
+        run: |
+          FILTERED_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '/.bun/bin' | paste -sd ':' -)
+          PATH="$FILTERED_PATH" node bin/lazypi.mjs doctor >/tmp/lazypi-doctor-no-bun.log 2>&1 || true
+          grep -q 'bun is not on PATH — official Compound Engineering from Every will be skipped by LazyPi' /tmp/lazypi-doctor-no-bun.log
+
+      - name: Compound-only install patches compat extension without requiring pi-subagents
+        run: |
+          TMPDIR=$(mktemp -d)
+          mkdir -p "$TMPDIR/proj"
+          cd "$TMPDIR/proj"
+          node "$GITHUB_WORKSPACE/bin/lazypi.mjs" --yes --only compound -l
+          test ! -f .pi/settings.json || ! grep -q 'npm:pi-subagents' .pi/settings.json
+          grep -q 'name: "ce_subagent"' .pi/extensions/compound-engineering-compat.ts
+
+      - name: Remove official Compound Engineering
+        run: node bin/lazypi.mjs remove compound
+
+      - name: Assert official Compound Engineering removed cleanly
+        run: |
+          test ! -e ~/.pi/agent/.lazypi/compound-engineering.json
+          test ! -e ~/.pi/agent/extensions/compound-engineering-compat.ts
+          test ! -d ~/.pi/agent/skills/ce-plan

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { argv, cwd, exit, stdout, stderr } from "node:process";
 import {
@@ -44,13 +44,21 @@ const PACKAGES = [
 	{ id: "interactive-shell", category: "ui", source: "npm:pi-interactive-shell", description: "Interactive shell overlays", hint: "Run Pi, Codex, editors, SSH, and long-running CLIs in observable overlays with hands-free and dispatch modes." },
 	{ id: "autoresearch", category: "research", source: "git:github.com/davebcn87/pi-autoresearch@5a29db080131449edc6d25a6b351b12879063366", description: "Autonomous experiment loop", hint: "Long-running autonomous research loop." },
 	{ id: "ralph-wiggum", category: "research", source: "npm:@tmustier/pi-ralph-wiggum", description: "Ralph Wiggum agent loop", hint: "Long-running iterative dev loops with goals, checklists, and optional self-reflection." },
-	{ id: "compound", category: "frameworks", source: "npm:@every-env/compound-plugin", description: "Compound Engineering workflow", hint: "Structured multi-step engineering workflow." },
+	{ id: "compound", category: "frameworks", source: "npm:@every-env/compound-plugin", description: "Official Compound Engineering", hint: "Official Every Pi target via Bun (skipped if Bun is unavailable)." },
 	{ id: "pi-themes", category: "themes", source: "npm:pi-themes", description: "Theme collection + picker", hint: "10 themes (Catppuccin, Dracula, Gruvbox, Nord, One Dark, Solarized, Tokyo Night) with a /themes picker command." },
 	{ id: "hackerman", category: "themes", source: "git:github.com/javierportillo/pi-hackerman@63b0a3ef2c7b14985ffeb6cac44614ba59cd5693", description: "Hackerman theme", hint: "Neon hacker-style color theme ported from the VS Code Hackerman Theme." },
 	{ id: "cyber-ui", category: "themes", source: "npm:pi-cyber-ui", description: "Cyber UI theme", hint: "Cyber-inspired dark theme with custom editor, compact footer, and working animation." },
 	{ id: "curated-themes", category: "themes", source: "npm:@victor-software-house/pi-curated-themes", description: "65 curated dark themes", hint: "65 dark terminal themes adapted from iTerm2-Color-Schemes." },
 	{ id: "terminal-theme", category: "themes", source: "npm:pi-terminal-theme", description: "Terminal ANSI theme", hint: "Maps Pi colors to ANSI 0–15 so Pi inherits your terminal's own color palette." },
 ];
+
+const COMPOUND_PKG_ID = "compound";
+const COMPOUND_SOURCE = "npm:@every-env/compound-plugin";
+const COMPOUND_PLUGIN_NAME = "compound-engineering";
+const COMPOUND_STATE_VERSION = 1;
+const COMPOUND_MANAGED_RELATIVE_PATHS = ["AGENTS.md", "prompts", "skills", "extensions", "compound-engineering"];
+const COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH = join("extensions", "compound-engineering-compat.ts");
+const COMPOUND_SUBAGENT_TOOL_NAME = "ce_subagent";
 
 // ---------------------------------------------------------------------------
 // Output helpers
@@ -305,6 +313,191 @@ function readInstalledSources(local) {
 	return { sources, path: current.path, exists: true };
 }
 
+function compoundInstallRoot(local) {
+	return local ? join(cwd(), ".pi") : join(homedir(), ".pi", "agent");
+}
+
+function compoundStatePath(local) {
+	return join(compoundInstallRoot(local), ".lazypi", "compound-engineering.json");
+}
+
+function readCompoundState(local) {
+	const path = compoundStatePath(local);
+	if (!existsSync(path)) return { path, exists: false, parsed: null, error: null };
+	try {
+		return { path, exists: true, parsed: JSON.parse(readFileSync(path, "utf8")), error: null };
+	} catch (err) {
+		return { path, exists: true, parsed: null, error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
+function writeCompoundState(local, state) {
+	const path = compoundStatePath(local);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+	return path;
+}
+
+function clearCompoundState(local) {
+	const path = compoundStatePath(local);
+	if (existsSync(path)) rmSync(path, { force: true });
+	const parent = dirname(path);
+	if (existsSync(parent) && readdirSync(parent).length === 0) rmSync(parent, { recursive: true, force: true });
+}
+
+function isCompoundInstalled(local) {
+	const state = readCompoundState(local);
+	return Boolean(state.exists && !state.error && state.parsed);
+}
+
+function normalizeRelativePath(path) {
+	return path.split("\\").join("/");
+}
+
+function collectManagedFiles(root, relativePath, files) {
+	const absolutePath = join(root, relativePath);
+	if (!existsSync(absolutePath)) return;
+	const stats = statSync(absolutePath);
+	if (stats.isFile()) {
+		files.set(normalizeRelativePath(relative(root, absolutePath)), readFileSync(absolutePath).toString("base64"));
+		return;
+	}
+	for (const name of readdirSync(absolutePath)) {
+		collectManagedFiles(root, join(relativePath, name), files);
+	}
+}
+
+function snapshotCompoundManagedFiles(local) {
+	const root = resolve(compoundInstallRoot(local));
+	const files = new Map();
+	for (const relativePath of COMPOUND_MANAGED_RELATIVE_PATHS) collectManagedFiles(root, relativePath, files);
+	return { root, files };
+}
+
+function pruneEmptyDirs(path) {
+	if (!existsSync(path) || !statSync(path).isDirectory()) return;
+	for (const entry of readdirSync(path)) pruneEmptyDirs(join(path, entry));
+	if (readdirSync(path).length === 0) rmSync(path, { recursive: true, force: true });
+}
+
+function removeEmptyManagedDirs(local) {
+	const root = compoundInstallRoot(local);
+	for (const dir of ["prompts", "skills", "extensions", "compound-engineering", ".lazypi"]) pruneEmptyDirs(join(root, dir));
+}
+
+function compoundCompatExtensionPath(local) {
+	return join(compoundInstallRoot(local), COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH);
+}
+
+function patchCompoundCompatExtension(local) {
+	const path = compoundCompatExtensionPath(local);
+	if (!existsSync(path)) return { ok: false, reason: `missing ${COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH}` };
+	const original = readFileSync(path, "utf8");
+	let patched = original;
+	patched = patched.replace('name: "subagent"', `name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`);
+	patched = patched.replace('label: "Subagent"', 'label: "CE Subagent"');
+	patched = patched.replace('description: "Run one or more skill-based subagent tasks. Supports single, parallel, and chained execution."', 'description: "Run one or more Compound Engineering skill-based subagent tasks. Supports single, parallel, and chained execution."');
+	if (patched === original || patched.includes('name: "subagent"')) {
+		return { ok: false, reason: `could not rename subagent tool to ${COMPOUND_SUBAGENT_TOOL_NAME}` };
+	}
+	writeFileSync(path, patched, "utf8");
+	return { ok: true, patched: true, path };
+}
+
+function patchCompoundTextFile(path, replacements) {
+	if (!existsSync(path)) return;
+	const original = readFileSync(path, "utf8");
+	let next = original;
+	for (const [pattern, replacement] of replacements) next = next.replace(pattern, replacement);
+	if (next !== original) writeFileSync(path, next, "utf8");
+}
+
+function patchCompoundGeneratedContent(local) {
+	const root = compoundInstallRoot(local);
+	patchCompoundTextFile(join(root, "AGENTS.md"), [
+		[/\bsubagent extension tool\b/g, `${COMPOUND_SUBAGENT_TOOL_NAME} extension tool`],
+		[/\bmulti_tool_use\.parallel\b/g, `${COMPOUND_SUBAGENT_TOOL_NAME} in parallel mode`],
+	]);
+	patchCompoundTextFile(join(root, "skills", "ce-plan", "SKILL.md"), [
+		[/Run subagent with/g, `Run ${COMPOUND_SUBAGENT_TOOL_NAME} with`],
+	]);
+	patchCompoundTextFile(join(root, "skills", "document-review", "SKILL.md"), [
+		[/Dispatch all agents in \*\*parallel\*\* using the platform's task\/agent tool/g, `Dispatch all agents in **parallel** using the \`${COMPOUND_SUBAGENT_TOOL_NAME}\` tool`],
+	]);
+	patchCompoundTextFile(join(root, "skills", "ce-review", "SKILL.md"), [
+		[/Omit the `mode` parameter when dispatching sub-agents/g, `Omit the \`mode\` parameter when dispatching with \`${COMPOUND_SUBAGENT_TOOL_NAME}\``],
+		[/Spawn each selected persona reviewer as a parallel sub-agent/g, `Spawn each selected persona reviewer with \`${COMPOUND_SUBAGENT_TOOL_NAME}\` in parallel`],
+	]);
+	patchCompoundTextFile(join(root, "skills", "ce-optimize", "SKILL.md"), [
+		[/Dispatch a subagent with the filled prompt/g, `Dispatch ${COMPOUND_SUBAGENT_TOOL_NAME} with the filled prompt`],
+		[/fall back to subagent/g, `fall back to ${COMPOUND_SUBAGENT_TOOL_NAME}`],
+	]);
+	patchCompoundTextFile(join(root, "skills", "ce-compound-refresh", "SKILL.md"), [
+		[/When spawning any subagent/g, `When spawning any subagent via \`${COMPOUND_SUBAGENT_TOOL_NAME}\``],
+	]);
+}
+
+function installCompound(local, interactive = false) {
+	if (!hasCmd("bun")) {
+		const reason = "bun is not on PATH — official Compound Engineering from Every will be skipped.";
+		if (interactive) log.warn(reason);
+		else console.log(`${yellow("  !")} ${reason}`);
+		return { status: "skipped", reason };
+	}
+
+	const targetRoot = resolve(compoundInstallRoot(local));
+	mkdirSync(targetRoot, { recursive: true });
+	const before = snapshotCompoundManagedFiles(local);
+	const args = ["@every-env/compound-plugin", "install", COMPOUND_PLUGIN_NAME, "--to", "pi", "--pi-home", targetRoot];
+	const status = spawnSync("bunx", args, { stdio: "inherit" }).status ?? 1;
+	if (status !== 0) return { status: "failed", code: status };
+
+	const patchResult = patchCompoundCompatExtension(local);
+	if (!patchResult.ok) return { status: "failed", code: 1, reason: patchResult.reason };
+	patchCompoundGeneratedContent(local);
+
+	const after = snapshotCompoundManagedFiles(local);
+	const createdFiles = [];
+	const modifiedFiles = [];
+	for (const [path, contentBase64] of after.files.entries()) {
+		if (!before.files.has(path)) createdFiles.push(path);
+		else if (before.files.get(path) !== contentBase64) modifiedFiles.push({ path, previousContentBase64: before.files.get(path) });
+	}
+
+	writeCompoundState(local, {
+		version: COMPOUND_STATE_VERSION,
+		source: COMPOUND_SOURCE,
+		root: targetRoot,
+		installedAt: new Date().toISOString(),
+		createdFiles: createdFiles.sort(),
+		modifiedFiles: modifiedFiles.sort((a, b) => a.path.localeCompare(b.path)),
+	});
+	return { status: "installed", count: createdFiles.length + modifiedFiles.length };
+}
+
+function removeCompound(local) {
+	const state = readCompoundState(local);
+	if (!state.exists) return 0;
+	if (state.error || !state.parsed) {
+		console.error(red(`Compound Engineering state file is invalid: ${state.error}`));
+		return 1;
+	}
+
+	const root = resolve(compoundInstallRoot(local));
+	const createdFiles = [...(state.parsed.createdFiles ?? [])].sort((a, b) => b.length - a.length);
+	for (const relativePath of createdFiles) rmSync(join(root, relativePath), { recursive: true, force: true });
+
+	for (const entry of state.parsed.modifiedFiles ?? []) {
+		const target = join(root, entry.path);
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(target, Buffer.from(entry.previousContentBase64, "base64"));
+	}
+
+	clearCompoundState(local);
+	removeEmptyManagedDirs(local);
+	return 0;
+}
+
 const DIFF_REVIEW_RELATIVE_DIR = join("git", "github.com", "badlogic", "pi-diff-review");
 const DIFF_REVIEW_GLIMPSE_FILE = join("node_modules", "glimpseui", "src", "chromium-backend.mjs");
 
@@ -356,8 +549,8 @@ function runPi(args) {
 	return result.status ?? 1;
 }
 
-function isPackageInstalled(pkg, installedPiSources) {
-	return installedPiSources.has(pkg.source);
+function isPackageInstalled(pkg, installedPiSources, local) {
+	return pkg.id === COMPOUND_PKG_ID ? isCompoundInstalled(local) : installedPiSources.has(pkg.source);
 }
 
 // ---------------------------------------------------------------------------
@@ -531,8 +724,9 @@ async function cmdInstall(flags) {
 	const { sources: installedSources, error: settingsError } = readInstalledSources(flags.local);
 	if (settingsError) log.warn(`Could not parse ${settingsPath(flags.local)} — ${settingsError}`);
 
-	const toInstall = selected.filter((p) => !isPackageInstalled(p, installedSources));
-	const alreadyInstalled = selected.filter((p) => isPackageInstalled(p, installedSources));
+	const forceIds = new Set(Array.isArray(flags.forceIds) ? flags.forceIds : []);
+	const toInstall = selected.filter((p) => forceIds.has(p.id) || !isPackageInstalled(p, installedSources, flags.local));
+	const alreadyInstalled = selected.filter((p) => !forceIds.has(p.id) && isPackageInstalled(p, installedSources, flags.local));
 	const scope = flags.local ? "project (.pi/settings.json)" : "global (~/.pi/agent/settings.json)";
 
 	const preInstallAuth = detectAuth();
@@ -586,8 +780,34 @@ async function cmdInstall(flags) {
 
 	const piArgs = flags.local ? ["install", "-l"] : ["install"];
 	const failed = [];
+	const skipped = [];
 
 	for (const pkg of toInstall) {
+		if (pkg.id === COMPOUND_PKG_ID) {
+			const action = `bunx @every-env/compound-plugin install ${COMPOUND_PLUGIN_NAME} --to pi`;
+			if (interactive) log.step(action);
+			else console.log(`\n→ ${action}`);
+			if (forceIds.has(COMPOUND_PKG_ID) && isCompoundInstalled(flags.local)) {
+				const removeStatus = removeCompound(flags.local);
+				if (removeStatus !== 0) {
+					failed.push(pkg);
+					if (interactive) log.error(`failed to refresh ${pkg.id}`);
+					else console.error(red(`  ✗ failed to refresh ${pkg.id}`));
+					continue;
+				}
+			}
+			const result = installCompound(flags.local, interactive);
+			if (result.status === "failed") {
+				failed.push(pkg);
+				const detail = result.reason ? ` (${result.reason})` : "";
+				if (interactive) log.error(`failed to install ${pkg.id}${detail}`);
+				else console.error(red(`  ✗ failed to install ${pkg.id}${detail}`));
+			} else if (result.status === "skipped") {
+				skipped.push(pkg);
+			}
+			continue;
+		}
+
 		const action = `pi install ${pkg.source}`;
 		if (interactive) log.step(action);
 		else console.log(`\n→ ${action}`);
@@ -620,10 +840,19 @@ async function cmdInstall(flags) {
 		}
 	}
 
+	const installedCount = toInstall.length - failed.length - skipped.length;
 	if (failed.length === 0) {
+		if (skipped.length > 0) {
+			const skipList = skipped.map((p) => `- ${p.id} (${p.source})`).join("\n");
+			if (interactive) note(skipList, "Skipped");
+			else {
+				console.log(yellow("\nSkipped packages:"));
+				console.log(skipList);
+			}
+		}
 		printCheatsheet(selected, interactive);
 		const authState = detectAuth();
-		printNextSteps(authState, toInstall.length, interactive);
+		printNextSteps(authState, installedCount, interactive);
 		return 0;
 	}
 
@@ -691,8 +920,8 @@ function cmdStatus(flags) {
 	}
 
 	const piCatalogSources = new Set(PACKAGES.map((p) => p.source));
-	const installed = PACKAGES.filter((p) => isPackageInstalled(p, sources));
-	const missing = PACKAGES.filter((p) => !isPackageInstalled(p, sources));
+	const installed = PACKAGES.filter((p) => isPackageInstalled(p, sources, flags.local));
+	const missing = PACKAGES.filter((p) => !isPackageInstalled(p, sources, flags.local));
 	const others = [...sources].filter((src) => !piCatalogSources.has(src));
 
 	printHeader(`Installed from LazyPi catalog (${installed.length}/${PACKAGES.length}):`);
@@ -721,7 +950,7 @@ async function cmdUpdate(flags) {
 	if (!(await ensurePi(flags))) return 127;
 
 	console.log(bold("Step 1/2: reconcile LazyPi catalog"));
-	const installCode = await cmdInstall({ ...flags, command: "install", yes: true });
+	const installCode = await cmdInstall({ ...flags, command: "install", yes: true, forceIds: [COMPOUND_PKG_ID] });
 	if (installCode !== 0) return installCode;
 
 	console.log(bold("\nStep 2/2: pi update"));
@@ -755,6 +984,9 @@ function cmdDoctor(flags) {
 	if (hasCmd("git")) pass("git is on PATH");
 	else warn("git is not on PATH — required by git-based catalog packages");
 
+	if (hasCmd("bun")) pass("bun is on PATH — required for official Compound Engineering from Every");
+	else warn("bun is not on PATH — official Compound Engineering from Every will be skipped by LazyPi");
+
 	printHeader("Pi");
 	if (hasCmd("pi")) {
 		pass("`pi` is on PATH");
@@ -785,6 +1017,19 @@ function cmdDoctor(flags) {
 		console.log(`  ${dim("·")} diff-review not installed`);
 	}
 
+	const compoundState = readCompoundState(flags.local);
+	if (compoundState.error) {
+		fail(`Compound Engineering state file is invalid — ${compoundState.error}`);
+	} else if (compoundState.exists) {
+		pass(`Compound Engineering managed state found at ${compoundState.path}`);
+		const compatPath = compoundCompatExtensionPath(flags.local);
+		if (!existsSync(compatPath)) fail(`Compound Engineering compat extension is missing at ${compatPath}`);
+		else if (readFileSync(compatPath, "utf8").includes(`name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`)) pass(`Compound Engineering compat tool renamed to ${COMPOUND_SUBAGENT_TOOL_NAME}`);
+		else fail(`Compound Engineering compat extension still registers the conflicting subagent tool`);
+	} else {
+		console.log(`  ${dim("·")} Compound Engineering not installed`);
+	}
+
 	printHeader("Auth");
 	const auth = detectAuth();
 	for (const { provider, envVar } of auth.envProviders) pass(`env var ${envVar} → ${provider}`);
@@ -810,7 +1055,7 @@ async function cmdRemove(flags, targets) {
 			return 2;
 		}
 		const { sources } = readInstalledSources(flags.local);
-		const installedPkgs = PACKAGES.filter((p) => isPackageInstalled(p, sources));
+		const installedPkgs = PACKAGES.filter((p) => isPackageInstalled(p, sources, flags.local));
 		if (installedPkgs.length === 0) {
 			console.log(yellow("No catalog packages are installed."));
 			return 0;
@@ -838,6 +1083,15 @@ async function cmdRemove(flags, targets) {
 		// Resolve a catalog id to its source string, or pass through raw sources
 		const pkg = PACKAGES.find((p) => p.id === target);
 		const source = pkg ? pkg.source : target;
+
+		if ((pkg && pkg.id === COMPOUND_PKG_ID) || source === COMPOUND_SOURCE) {
+			const result = removeCompound(flags.local);
+			if (result !== 0) {
+				console.error(red(`Failed to remove ${target}`));
+				exitCode = 1;
+			}
+			continue;
+		}
 
 		const piArgs = flags.local ? ["remove", "-l", source] : ["remove", source];
 		const result = spawnSync("pi", piArgs, { stdio: "inherit" });

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -105,7 +105,7 @@
       <tbody>
         <tr>
           <td>Skills</td>
-          <td>50+ workflow, review, and planning commands via Compound Engineering</td>
+          <td>Official Every planning and review skills via Compound Engineering's Pi target</td>
         </tr>
         <tr>
           <td>Themes</td>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -85,8 +85,10 @@
     <ul>
       <li>Node.js 18 or later</li>
       <li>npm (bundled with Node.js)</li>
+      <li><strong>Optional:</strong> Bun, if you want the official Compound Engineering package from Every</li>
     </ul>
     <p>You do not need to install LazyPi globally. <code>npx</code> downloads and runs it on demand.</p>
+    <p>If Bun is missing, LazyPi still installs everything else. It simply warns that Compound Engineering will be skipped.</p>
 
     <h2>Run it</h2>
     <pre><code>npx @robzolkos/lazypi</code></pre>

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -105,31 +105,68 @@
       LazyPi tracks the files it generates for the official Pi target, so <code>npx @robzolkos/lazypi remove compound</code> removes the generated Compound Engineering files cleanly instead of leaving converted skills behind.
     </p>
 
-    <h2>LazyPi compatibility patch</h2>
+    <h2>What shows up in Pi</h2>
     <p>
-      LazyPi keeps the official Every-generated skills and compatibility layer, but renames the generated delegation tool to <code>ce_subagent</code> so it can coexist with other Pi packages that also register a <code>subagent</code> tool. The Compound Engineering skills are patched to call <code>ce_subagent</code> explicitly, preserving the upstream skill-based delegation behavior without colliding with the rest of the LazyPi stack.
+      The official Pi target installs a large skill library and supporting tooling rather than a single npm-style Pi package manifest entry. In practice, you get the core Compound Engineering workflows plus a broad bench of reviewer, researcher, planning, testing, and shipping skills that those workflows can call.
     </p>
 
-    <h2>What shows up in Pi</h2>
-    <p>The official Pi target currently installs skills and compatibility files rather than a separate npm-style Pi package manifest.</p>
-
-    <h3>Primary workflow skills</h3>
+    <h3>Core Compound Engineering workflow skills</h3>
     <table>
       <thead>
         <tr><th>Skill</th><th>What it does</th></tr>
       </thead>
       <tbody>
-        <tr><td><code>/skill:ce:brainstorm</code></td><td>Explore requirements and approaches before planning</td></tr>
-        <tr><td><code>/skill:ce:plan</code></td><td>Create structured implementation plans</td></tr>
-        <tr><td><code>/skill:ce:work</code></td><td>Execute planned work systematically</td></tr>
-        <tr><td><code>/skill:ce:review</code></td><td>Run multi-agent review before shipping</td></tr>
-        <tr><td><code>/skill:ce:compound</code></td><td>Capture learnings for future sessions</td></tr>
+        <tr><td><code>/skill:ce:brainstorm</code></td><td>Explore requirements, constraints, and options before committing to a build</td></tr>
+        <tr><td><code>/skill:ce:ideate</code></td><td>Generate and critique grounded ideas before narrowing to a direction</td></tr>
+        <tr><td><code>/skill:ce:plan</code></td><td>Create a structured implementation plan with repo research and plan review</td></tr>
+        <tr><td><code>/skill:ce:work</code></td><td>Execute implementation work against an approved plan</td></tr>
+        <tr><td><code>/skill:ce:review</code></td><td>Run tiered multi-agent code review before shipping</td></tr>
+        <tr><td><code>/skill:ce-debug</code></td><td>Investigate bugs and root causes systematically</td></tr>
+        <tr><td><code>/skill:ce:compound</code></td><td>Capture a solved problem as reusable institutional knowledge</td></tr>
+        <tr><td><code>/skill:ce-compound-refresh</code></td><td>Refresh and consolidate stale learning docs under <code>docs/solutions/</code></td></tr>
+        <tr><td><code>/skill:ce-setup</code></td><td>Verify the Compound Engineering environment and troubleshoot setup issues</td></tr>
       </tbody>
     </table>
 
-    <h3>Additional tooling</h3>
+    <h3>Research, planning, and review helpers</h3>
+    <table>
+      <thead>
+        <tr><th>Skill</th><th>What it does</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>/skill:repo-research-analyst</code></td><td>Research repo structure, patterns, conventions, and relevant files</td></tr>
+        <tr><td><code>/skill:learnings-researcher</code></td><td>Search <code>docs/solutions/</code> for prior institutional learnings</td></tr>
+        <tr><td><code>/skill:framework-docs-researcher</code></td><td>Pull official framework or library guidance</td></tr>
+        <tr><td><code>/skill:best-practices-researcher</code></td><td>Gather external best practices and implementation examples</td></tr>
+        <tr><td><code>/skill:spec-flow-analyzer</code></td><td>Check specs and plans for missing flows, edges, and handoffs</td></tr>
+        <tr><td><code>/skill:document-review</code></td><td>Review requirements and plan documents with multiple personas</td></tr>
+        <tr><td><code>/skill:architecture-strategist</code></td><td>Stress-test architectural decisions and system-wide impact</td></tr>
+        <tr><td><code>/skill:security-sentinel</code></td><td>Audit for security risks and missing defenses</td></tr>
+        <tr><td><code>/skill:performance-oracle</code></td><td>Review performance, scalability, and bottlenecks</td></tr>
+        <tr><td><code>/skill:data-integrity-guardian</code></td><td>Review data safety, migration risk, and persistence concerns</td></tr>
+      </tbody>
+    </table>
+
+    <h3>Shipping, communication, and utility skills</h3>
+    <table>
+      <thead>
+        <tr><th>Skill</th><th>What it does</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>/skill:ce-pr-description</code></td><td>Draft or refresh a value-first pull request title and body</td></tr>
+        <tr><td><code>/skill:resolve-pr-feedback</code></td><td>Work through PR review comments and thread resolution</td></tr>
+        <tr><td><code>/skill:ce-demo-reel</code></td><td>Create screenshots, GIFs, or recordings for visual proof</td></tr>
+        <tr><td><code>/skill:ce-optimize</code></td><td>Run iterative metric-driven optimization loops</td></tr>
+        <tr><td><code>/skill:proof</code></td><td>Push docs into Proof for human-in-the-loop review and iteration</td></tr>
+        <tr><td><code>/skill:test-browser</code></td><td>Run browser-based testing for affected pages</td></tr>
+        <tr><td><code>/skill:test-xcode</code></td><td>Build and test iOS apps on simulator with Xcode tooling</td></tr>
+        <tr><td><code>/skill:git-commit</code></td><td>Create clear commits with strong messages</td></tr>
+        <tr><td><code>/skill:git-commit-push-pr</code></td><td>Commit, push, and open a PR in one workflow</td></tr>
+      </tbody>
+    </table>
+
     <p>
-      The install also adds many specialist reviewer and research skills, an official Pi compatibility extension, MCPorter config output, and an AGENTS block that documents the tool mapping used by the upstream plugin.
+      Those tables are the most visible entry points, not the full inventory. The official install currently brings in dozens more specialist personas and helpers, including language-specific reviewers, design tools, deployment verification, session history search, Slack research, todo workflows, onboarding generation, and autonomous workflows like <code>/skill:lfg</code>.
     </p>
 
     <div class="learn-more">

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -77,73 +77,60 @@
 
   <main class="docs-content">
     <h1>Compound Engineering</h1>
-    <p class="page-desc">Every's AI coding methodology — 50+ agents, 42+ skills, and the full sprint lifecycle in one plugin.</p>
+    <p class="page-desc">Official Compound Engineering from Every, installed through the upstream Pi target converter.</p>
 
     <h2>What it does</h2>
     <p>
-      The Compound Engineering plugin from Every encodes their 80/20 AI coding philosophy as a complete set of slash commands: 80% of the work is planning and review, 20% is execution. The plugin ships 50+ agents and 42+ skills covering the full software development lifecycle — from ideation through brainstorming, planning, implementation, code review, debugging, optimization, and knowledge compounding.
+      LazyPi installs the official <code>@every-env/compound-plugin</code> package from Every and runs its Pi target converter. That upstream tool generates Pi-compatible skills, extensions, and agent guidance directly into your Pi config directory.
     </p>
     <p>
-      Standout capabilities include multi-agent code review with confidence gating, iterative optimization loops using LLM-as-judge, session history research across Claude Code, Codex, and Cursor, Slack context lookup for organizational knowledge, and a knowledge compounding system that documents solved problems to prevent repeat work.
+      In practice, this gives Pi the official Compound Engineering reviewer and workflow skill set — including entry points like <code>/skill:ce:plan</code>, <code>/skill:ce:work</code>, <code>/skill:ce:review</code>, <code>/skill:ce:brainstorm</code>, and <code>/skill:ce:compound</code> — plus the compatibility layer required for subagents and MCP-style access.
     </p>
     <p>
-      The plugin works across Claude Code, Pi, Cursor, Codex, and 8 other agents — so workflows transfer across tools.
+      After installing LazyPi, restart or <code>/reload</code> Pi so the generated skills and extensions are loaded into the current session.
+    </p>
+
+    <h2>Bun requirement</h2>
+    <p>
+      The official Every installer is a Bun-based CLI. LazyPi checks for <code>bun</code> before attempting this package. If Bun is missing, LazyPi will warn you and continue installing everything else, but Compound Engineering will be skipped.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Compound Engineering is one of the most complete and battle-tested AI engineering methodologies available. Every has been building with AI agents longer than most, and the plugin reflects real lessons about what makes multi-agent coding workflows succeed. It's the closest thing to a complete playbook for AI-assisted engineering.
+      Compound Engineering remains one of the strongest AI-assisted development methodologies available, and using the upstream package keeps LazyPi aligned with Every's official implementation instead of a third-party fork or repackaging.
     </p>
 
-    <h2>Commands</h2>
-    <p>All commands are prefixed with <code>/ce-</code>.</p>
+    <h2>Removal</h2>
+    <p>
+      LazyPi tracks the files it generates for the official Pi target, so <code>npx @robzolkos/lazypi remove compound</code> removes the generated Compound Engineering files cleanly instead of leaving converted skills behind.
+    </p>
 
-    <h3>Core workflow</h3>
+    <h2>LazyPi compatibility patch</h2>
+    <p>
+      LazyPi keeps the official Every-generated skills and compatibility layer, but renames the generated delegation tool to <code>ce_subagent</code> so it can coexist with other Pi packages that also register a <code>subagent</code> tool. The Compound Engineering skills are patched to call <code>ce_subagent</code> explicitly, preserving the upstream skill-based delegation behavior without colliding with the rest of the LazyPi stack.
+    </p>
+
+    <h2>What shows up in Pi</h2>
+    <p>The official Pi target currently installs skills and compatibility files rather than a separate npm-style Pi package manifest.</p>
+
+    <h3>Primary workflow skills</h3>
     <table>
       <thead>
-        <tr><th>Command</th><th>What it does</th></tr>
+        <tr><th>Skill</th><th>What it does</th></tr>
       </thead>
       <tbody>
-        <tr><td><code>/ce-brainstorm</code></td><td>Explore requirements and approaches — main entry point</td></tr>
-        <tr><td><code>/ce-ideate</code></td><td>Divergent ideation with adversarial filtering</td></tr>
-        <tr><td><code>/ce-plan</code></td><td>Turn ideas into detailed implementation plans</td></tr>
-        <tr><td><code>/ce-work</code></td><td>Execute work items systematically</td></tr>
-        <tr><td><code>/ce-code-review</code></td><td>Multi-agent structured code review with confidence gating</td></tr>
-        <tr><td><code>/ce-debug</code></td><td>Root-cause debugging with causal chains and test-first fixes</td></tr>
-        <tr><td><code>/ce-optimize</code></td><td>Iterative optimization with parallel experiments and LLM-as-judge</td></tr>
-        <tr><td><code>/ce-compound</code></td><td>Document solved problems to compound team knowledge</td></tr>
-        <tr><td><code>/ce-compound-refresh</code></td><td>Refresh stale learnings</td></tr>
+        <tr><td><code>/skill:ce:brainstorm</code></td><td>Explore requirements and approaches before planning</td></tr>
+        <tr><td><code>/skill:ce:plan</code></td><td>Create structured implementation plans</td></tr>
+        <tr><td><code>/skill:ce:work</code></td><td>Execute planned work systematically</td></tr>
+        <tr><td><code>/skill:ce:review</code></td><td>Run multi-agent review before shipping</td></tr>
+        <tr><td><code>/skill:ce:compound</code></td><td>Capture learnings for future sessions</td></tr>
       </tbody>
     </table>
 
-    <h3>Research &amp; context</h3>
-    <table>
-      <thead>
-        <tr><th>Command</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><code>/ce-sessions</code></td><td>Query session history across Claude Code, Codex, Cursor</td></tr>
-        <tr><td><code>/ce-slack-research</code></td><td>Search Slack for organizational context</td></tr>
-      </tbody>
-    </table>
-
-    <h3>Workflow utilities</h3>
-    <table>
-      <thead>
-        <tr><th>Command</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><code>/ce-resolve-pr-feedback</code></td><td>Resolve PR review feedback in parallel</td></tr>
-        <tr><td><code>/ce-todo-resolve</code></td><td>Resolve todos in parallel</td></tr>
-        <tr><td><code>/ce-todo-triage</code></td><td>Triage and prioritize todos</td></tr>
-        <tr><td><code>/ce-polish-beta</code></td><td>Human-in-the-loop polish phase after code review</td></tr>
-        <tr><td><code>/ce-demo-reel</code></td><td>Capture GIF/terminal/screenshot demo reels for PRs</td></tr>
-        <tr><td><code>/ce-changelog</code></td><td>Create engaging changelogs for recent merges</td></tr>
-        <tr><td><code>/ce-onboarding</code></td><td>Generate ONBOARDING.md for new contributors</td></tr>
-        <tr><td><code>/ce-setup</code></td><td>Diagnose environment, install missing tools, bootstrap config</td></tr>
-        <tr><td><code>/ce-update</code></td><td>Check plugin version and fix stale cache</td></tr>
-      </tbody>
-    </table>
+    <h3>Additional tooling</h3>
+    <p>
+      The install also adds many specialist reviewer and research skills, an official Pi compatibility extension, MCPorter config output, and an AGENTS block that documents the tool mapping used by the upstream plugin.
+    </p>
 
     <div class="learn-more">
       <a href="https://github.com/EveryInc/compound-engineering-plugin" target="_blank" rel="noopener">→ GitHub — EveryInc/compound-engineering-plugin</a>

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -164,7 +164,7 @@
       <a class="pkg-card" href="/docs/packages/compound-engineering.html">
         <span class="pkg-tag frameworks">frameworks</span>
         <div class="pkg-name">Compound Engineering</div>
-        <div class="pkg-desc">Every's AI coding methodology — 50+ agents and 42+ skills for the full sprint lifecycle</div>
+        <div class="pkg-desc">Official Every Compound Engineering for Pi, installed through the upstream Bun-based Pi target converter</div>
       </a>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -779,7 +779,7 @@
           <td><span class="check">✓</span></td>
         </tr>
         <tr>
-          <td>Compound Engineering from Every</td>
+          <td>Official Compound Engineering</td>
           <td><span class="cross">✕</span></td>
           <td><span class="check">✓</span></td>
         </tr>
@@ -878,9 +878,9 @@
       </a>
       <a class="catalog-card" href="https://github.com/EveryInc/compound-engineering-plugin" target="_blank" rel="noopener">
         <span class="catalog-tag frameworks">frameworks</span>
-        <div class="catalog-name">Compound Engineering from Every</div>
-        <div class="catalog-desc">Structured multi-step engineering workflow</div>
-        <div class="catalog-author">by Every</div>
+        <div class="catalog-name">Official Compound Engineering</div>
+        <div class="catalog-desc">Every's planning and review methodology for Pi via the official upstream converter</div>
+        <div class="catalog-author">by Every (requires Bun)</div>
       </a>
       <a class="catalog-card" href="/themes.html">
         <span class="catalog-tag themes">themes</span>


### PR DESCRIPTION
## Summary
- switch LazyPi Compound Engineering support to the official Every installer path
- patch the generated Pi compat layer to use a namespaced `ce_subagent` tool so it can coexist with other Pi extensions
- update docs and doctor output for the Bun requirement and verified CE skill invocation names
- add regression coverage for the generated CE compat tool delegation path in GitHub Actions

## What changed
- installs official `@every-env/compound-plugin` via `bunx ... --to pi`
- tracks/removes generated Compound files through LazyPi-managed state
- renames the generated Compound compat tool from `subagent` to `ce_subagent`
- patches generated CE files so CE workflows keep their own skill-based delegation semantics
- verifies `doctor` warns when Bun is missing
- verifies `ce_subagent` delegates via `/skill:repo-research-analyst`

## Why
The official Compound Pi target was colliding with `subagent` tools from other Pi packages. Routing CE onto `pi-subagents` removed the collision but broke CE's own delegation semantics. This patch preserves the official CE behavior while avoiding the tool-name conflict.

## Testing
- node --check bin/lazypi.mjs
- YAML parse of `.github/workflows/test.yml`
- local install/remove smoke tests for official Compound Engineering
- local CE planning workflow smoke test showing successful `ce_subagent` delegation
- local deterministic compat-extension test asserting `ce_subagent` builds `/skill:repo-research-analyst ...`
