### PR TITLE
Normalize Compound skill names to match current Pi rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,21 @@ jobs:
           console.log('verified ce_subagent preserves /skill-based delegation semantics');
           EOF
 
+      - name: Doctor warns when auth missing but succeeds
+        run: |
+          set -euo pipefail
+          AUTH_PATH="$HOME/.pi/agent/auth.json"
+          BACKUP_PATH="$HOME/.pi/agent/auth.json.lazypi-test-backup"
+          cleanup() {
+            if [ -f "$BACKUP_PATH" ]; then mv "$BACKUP_PATH" "$AUTH_PATH"; fi
+          }
+          trap cleanup EXIT
+          if [ -f "$AUTH_PATH" ]; then mv "$AUTH_PATH" "$BACKUP_PATH"; fi
+          env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GOOGLE_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY -u TOGETHER_API_KEY -u GROQ_API_KEY -u MISTRAL_API_KEY \
+            node bin/lazypi.mjs doctor >/tmp/lazypi-doctor-no-auth.log 2>&1
+          grep -q 'No credentials detected — run `pi` then `/login`, or export a provider API key' /tmp/lazypi-doctor-no-auth.log
+          grep -q '1 warning(s) found\.' /tmp/lazypi-doctor-no-auth.log
+
       - name: Doctor warns when bun missing
         run: |
           FILTERED_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '/.bun/bin' | paste -sd ':' -)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,10 +87,25 @@ jobs:
           test -f ~/.pi/agent/extensions/compound-engineering-compat.ts
           test -f ~/.pi/agent/skills/ce-plan/SKILL.md
           grep -q '"source": "npm:@every-env/compound-plugin"' ~/.pi/agent/.lazypi/compound-engineering.json
-          grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          grep -q '^name: ce-plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          ! grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
           grep -q 'name: "ce_subagent"' ~/.pi/agent/extensions/compound-engineering-compat.ts
           grep -q 'Claude Task(agent, args) maps to the ce_subagent extension tool' ~/.pi/agent/AGENTS.md
           grep -q 'Run ce_subagent with agent="repo-research-analyst"' ~/.pi/agent/skills/ce-plan/SKILL.md
+
+      - name: Rerun repairs existing Compound skill names
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          path = Path.home() / ".pi" / "agent" / "skills" / "ce-plan" / "SKILL.md"
+          text = path.read_text()
+          path.write_text(text.replace("name: ce-plan", "name: ce:plan", 1))
+          PY
+          grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          node bin/lazypi.mjs --yes
+          grep -q '^name: ce-plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          ! grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
+          node bin/lazypi.mjs doctor
 
       - name: Assert CE compat tool preserves skill delegation semantics
         run: |

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -1055,10 +1055,12 @@ async function cmdUpdate(flags) {
 // ---------------------------------------------------------------------------
 function cmdDoctor(flags) {
 	let problems = 0;
+	let warnings = 0;
 	const pass = (msg) => console.log(`  ${green("✓")} ${msg}`);
-	const warn = (msg) => {
+	const warn = (msg, { fatal = true } = {}) => {
 		console.log(`  ${yellow("!")} ${msg}`);
-		problems++;
+		if (fatal) problems++;
+		else warnings++;
 	};
 	const fail = (msg) => {
 		console.log(`  ${red("✗")} ${msg}`);
@@ -1129,14 +1131,18 @@ function cmdDoctor(flags) {
 	const auth = detectAuth();
 	for (const { provider, envVar } of auth.envProviders) pass(`env var ${envVar} → ${provider}`);
 	if (auth.fileProviders.length > 0) pass(`${auth.path} → ${auth.fileProviders.join(", ")}`);
-	if (!auth.authed) warn("No credentials detected — run `pi` then `/login`, or export a provider API key");
+	if (!auth.authed) warn("No credentials detected — run `pi` then `/login`, or export a provider API key", { fatal: false });
 
 	console.log("");
-	if (problems === 0) {
+	if (problems === 0 && warnings === 0) {
 		console.log(green("All checks passed."));
 		return 0;
 	}
-	console.log(yellow(`${problems} problem(s) found.`));
+	if (problems === 0) {
+		console.log(yellow(`${warnings} warning(s) found.`));
+		return 0;
+	}
+	console.log(yellow(`${problems} problem(s) found${warnings ? `, ${warnings} warning(s)` : ""}.`));
 	return 1;
 }
 

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -393,6 +393,7 @@ function patchCompoundCompatExtension(local) {
 	const path = compoundCompatExtensionPath(local);
 	if (!existsSync(path)) return { ok: false, reason: `missing ${COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH}` };
 	const original = readFileSync(path, "utf8");
+	if (original.includes(`name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`)) return { ok: true, patched: false, path };
 	let patched = original;
 	patched = patched.replace('name: "subagent"', `name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`);
 	patched = patched.replace('label: "Subagent"', 'label: "CE Subagent"');
@@ -410,6 +411,72 @@ function patchCompoundTextFile(path, replacements) {
 	let next = original;
 	for (const [pattern, replacement] of replacements) next = next.replace(pattern, replacement);
 	if (next !== original) writeFileSync(path, next, "utf8");
+}
+
+function listCompoundSkillNameConflicts(local) {
+	const root = compoundInstallRoot(local);
+	const skillsRoot = join(root, "skills");
+	if (!existsSync(skillsRoot)) return [];
+	const conflicts = [];
+	for (const entry of readdirSync(skillsRoot)) {
+		const skillDir = join(skillsRoot, entry);
+		if (!statSync(skillDir).isDirectory()) continue;
+		const skillFile = join(skillDir, "SKILL.md");
+		if (!existsSync(skillFile)) continue;
+		const original = readFileSync(skillFile, "utf8");
+		const frontmatterMatch = original.match(/^---\n([\s\S]*?)\n---/);
+		if (!frontmatterMatch) continue;
+		const nameMatch = frontmatterMatch[1].match(/^name:\s*(.+)\s*$/m);
+		if (!nameMatch) continue;
+		const currentName = nameMatch[1].trim().replace(/^['"]|['"]$/g, "");
+		if (!currentName || currentName === entry) continue;
+		conflicts.push({
+			path: normalizeRelativePath(relative(root, skillFile)),
+			absolutePath: skillFile,
+			currentName,
+			expectedName: entry,
+		});
+	}
+	return conflicts;
+}
+
+function normalizeCompoundSkillFrontmatter(local) {
+	const conflicts = listCompoundSkillNameConflicts(local);
+	const nameMap = new Map(conflicts.map((conflict) => [conflict.currentName, conflict.expectedName]));
+	const patchedFiles = [];
+	for (const conflict of conflicts) {
+		const original = readFileSync(conflict.absolutePath, "utf8");
+		const next = original.replace(/^name:\s*.+$/m, `name: ${conflict.expectedName}`);
+		if (next === original) continue;
+		writeFileSync(conflict.absolutePath, next, "utf8");
+		patchedFiles.push(conflict.path);
+	}
+	return { nameMap, patchedFiles };
+}
+
+function patchCompoundSkillReferences(local, nameMap) {
+	if (nameMap.size === 0) return [];
+	const root = compoundInstallRoot(local);
+	const replacements = [...nameMap.entries()].sort((a, b) => b[0].length - a[0].length);
+	const patchedFiles = [];
+	const visit = (relativePath) => {
+		const absolutePath = join(root, relativePath);
+		if (!existsSync(absolutePath)) return;
+		const stats = statSync(absolutePath);
+		if (stats.isDirectory()) {
+			for (const name of readdirSync(absolutePath)) visit(join(relativePath, name));
+			return;
+		}
+		if (!/\.(md|json|ts|ya?ml|txt|sh)$/i.test(relativePath)) return;
+		const original = readFileSync(absolutePath, "utf8");
+		let next = original;
+		for (const [oldName, newName] of replacements) next = next.split(oldName).join(newName);
+		if (next === original) return;
+		writeFileSync(absolutePath, next, "utf8");
+		patchedFiles.push(normalizeRelativePath(relative(root, absolutePath)));
+	};
+	for (const relativePath of COMPOUND_MANAGED_RELATIVE_PATHS) visit(relativePath);
+	return patchedFiles;
 }
 
 function patchCompoundGeneratedContent(local) {
@@ -435,6 +502,18 @@ function patchCompoundGeneratedContent(local) {
 	patchCompoundTextFile(join(root, "skills", "ce-compound-refresh", "SKILL.md"), [
 		[/When spawning any subagent/g, `When spawning any subagent via \`${COMPOUND_SUBAGENT_TOOL_NAME}\``],
 	]);
+	const { nameMap } = normalizeCompoundSkillFrontmatter(local);
+	patchCompoundSkillReferences(local, nameMap);
+}
+
+function repairInstalledCompound(local) {
+	if (!isCompoundInstalled(local)) return { status: "missing" };
+	const patchResult = patchCompoundCompatExtension(local);
+	if (!patchResult.ok) return { status: "failed", code: 1, reason: patchResult.reason };
+	patchCompoundGeneratedContent(local);
+	const remainingConflicts = listCompoundSkillNameConflicts(local).length;
+	if (remainingConflicts > 0) return { status: "failed", code: 1, reason: `${remainingConflicts} skill name conflict(s) remain after repair` };
+	return { status: "repaired" };
 }
 
 function installCompound(local, interactive = false) {
@@ -754,6 +833,19 @@ async function cmdInstall(flags) {
 		}
 	}
 
+	if (selected.some((p) => p.id === COMPOUND_PKG_ID) && isCompoundInstalled(flags.local) && !forceIds.has(COMPOUND_PKG_ID)) {
+		const repairResult = repairInstalledCompound(flags.local);
+		if (repairResult.status === "failed") {
+			const message = `Failed to repair existing Compound Engineering install${repairResult.reason ? ` (${repairResult.reason})` : ""}.`;
+			if (interactive) {
+				log.error(message);
+				outro(red("Aborted."));
+			} else {
+				console.error(red(message));
+			}
+			return repairResult.code ?? 1;
+		}
+	}
 
 	if (toInstall.length === 0) {
 		if (selected.some((p) => p.id === "pi-themes")) {
@@ -1026,6 +1118,9 @@ function cmdDoctor(flags) {
 		if (!existsSync(compatPath)) fail(`Compound Engineering compat extension is missing at ${compatPath}`);
 		else if (readFileSync(compatPath, "utf8").includes(`name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`)) pass(`Compound Engineering compat tool renamed to ${COMPOUND_SUBAGENT_TOOL_NAME}`);
 		else fail(`Compound Engineering compat extension still registers the conflicting subagent tool`);
+		const skillNameConflicts = listCompoundSkillNameConflicts(flags.local);
+		if (skillNameConflicts.length === 0) pass("Compound skill names normalized to Pi's current skill spec");
+		else fail(`Compound generated skills still have ${skillNameConflicts.length} Pi-incompatible name conflict(s)`);
 	} else {
 		console.log(`  ${dim("·")} Compound Engineering not installed`);
 	}

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -84,7 +84,10 @@
       LazyPi installs the official <code>@every-env/compound-plugin</code> package from Every and runs its Pi target converter. That upstream tool generates Pi-compatible skills, extensions, and agent guidance directly into your Pi config directory.
     </p>
     <p>
-      In practice, this gives Pi the official Compound Engineering reviewer and workflow skill set — including entry points like <code>/skill:ce:plan</code>, <code>/skill:ce:work</code>, <code>/skill:ce:review</code>, <code>/skill:ce:brainstorm</code>, and <code>/skill:ce:compound</code> — plus the compatibility layer required for subagents and MCP-style access.
+      In practice, this gives Pi the official Compound Engineering reviewer and workflow skill set — including entry points like <code>/skill:ce-plan</code>, <code>/skill:ce-work</code>, <code>/skill:ce-review</code>, <code>/skill:ce-brainstorm</code>, and <code>/skill:ce-compound</code> — plus the compatibility layer required for subagents and MCP-style access.
+    </p>
+    <p>
+      LazyPi also normalizes the upstream colon-style Compound skill IDs into Pi-compatible hyphenated IDs (for example <code>ce:plan</code> → <code>ce-plan</code>) so current Pi releases do not emit skill-name warnings. That normalization is re-applied on every Compound reinstall or <code>lazypi update</code>.
     </p>
     <p>
       After installing LazyPi, restart or <code>/reload</code> Pi so the generated skills and extensions are loaded into the current session.
@@ -116,13 +119,13 @@
         <tr><th>Skill</th><th>What it does</th></tr>
       </thead>
       <tbody>
-        <tr><td><code>/skill:ce:brainstorm</code></td><td>Explore requirements, constraints, and options before committing to a build</td></tr>
-        <tr><td><code>/skill:ce:ideate</code></td><td>Generate and critique grounded ideas before narrowing to a direction</td></tr>
-        <tr><td><code>/skill:ce:plan</code></td><td>Create a structured implementation plan with repo research and plan review</td></tr>
-        <tr><td><code>/skill:ce:work</code></td><td>Execute implementation work against an approved plan</td></tr>
-        <tr><td><code>/skill:ce:review</code></td><td>Run tiered multi-agent code review before shipping</td></tr>
+        <tr><td><code>/skill:ce-brainstorm</code></td><td>Explore requirements, constraints, and options before committing to a build</td></tr>
+        <tr><td><code>/skill:ce-ideate</code></td><td>Generate and critique grounded ideas before narrowing to a direction</td></tr>
+        <tr><td><code>/skill:ce-plan</code></td><td>Create a structured implementation plan with repo research and plan review</td></tr>
+        <tr><td><code>/skill:ce-work</code></td><td>Execute implementation work against an approved plan</td></tr>
+        <tr><td><code>/skill:ce-review</code></td><td>Run tiered multi-agent code review before shipping</td></tr>
         <tr><td><code>/skill:ce-debug</code></td><td>Investigate bugs and root causes systematically</td></tr>
-        <tr><td><code>/skill:ce:compound</code></td><td>Capture a solved problem as reusable institutional knowledge</td></tr>
+        <tr><td><code>/skill:ce-compound</code></td><td>Capture a solved problem as reusable institutional knowledge</td></tr>
         <tr><td><code>/skill:ce-compound-refresh</code></td><td>Refresh and consolidate stale learning docs under <code>docs/solutions/</code></td></tr>
         <tr><td><code>/skill:ce-setup</code></td><td>Verify the Compound Engineering environment and troubleshoot setup issues</td></tr>
       </tbody>


### PR DESCRIPTION
### Summary
LazyPi installs the official Compound Engineering Pi target, but current Pi releases warn when generated skill names use colon-style IDs like `ce:plan` instead of directory-matching hyphenated names. This PR adds a small compatibility normalization layer so official Compound output remains usable without noisy startup warnings, repairs existing installs on ordinary LazyPi reruns, and locks the behavior into CI.

Ref: https://github.com/robzolkos/LazyPi/issues/17

### What changed
- normalize generated Compound skill frontmatter from colon-style names to Pi-compatible hyphenated names
- rewrite generated Compound references so the normalized names stay internally consistent
- repair already-installed Compound output during normal `lazypi --yes` reruns, not only forced refresh/update paths
- make the Compound compat patch idempotent so repeated repairs are safe
- extend `lazypi doctor` to surface whether Compound skill names still violate current Pi rules
- update Compound docs to show the Pi-facing hyphenated skill commands
- add an e2e regression test that corrupts one installed Compound skill name, reruns LazyPi, and verifies the repair happens
