### PR TITLE
docs: add missing package docs and catalog entries

### DIFF
--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -66,8 +66,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -66,8 +66,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -66,8 +66,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -63,8 +63,11 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link active">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link active">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/diff-review.html
+++ b/docs/docs/packages/diff-review.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/extension-settings.html
+++ b/docs/docs/packages/extension-settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Simplify — LazyPi Docs</title>
+  <title>Extension Settings — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -60,13 +60,12 @@
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
-      <a href="/docs/packages/simplify.html" class="sidebar-link active">Simplify</a>
+      <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
-      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link active">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
       <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
@@ -79,20 +78,20 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Simplify</h1>
-    <p class="page-desc">Reviews recently changed code for clarity, consistency, and maintainability — never changes behavior.</p>
+    <h1>Extension Settings</h1>
+    <p class="page-desc">Centralized settings UI and storage layer that other Pi extensions can register with.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-simplify reads every file that changed in your working tree, applies clarity and consistency improvements one at a time, then runs your test suite after each change to verify nothing broke. It operates on a strict constraint: it may only improve how the code reads, never what it does.
+      Pi Extension Settings gives Pi extensions a shared place to declare configurable options and a standard UI for editing them. Instead of each package inventing its own config file or command syntax, extensions can register settings and let users manage them from one screen.
     </p>
     <p>
-      This means simplify is safe to run after any implementation pass. It won't introduce regressions because it won't change logic. What it will do is catch naming inconsistencies, overly complex expressions, unnecessary nesting, and other readability issues that are easy to miss when you're focused on getting the feature to work.
+      In the LazyPi stack it mainly acts as a companion package for Powerbar. Powerbar registers its options at load time, and Extension Settings provides the persistent storage and interactive settings editor those options depend on.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Implementation and cleanup are cognitively different tasks. Trying to do both at once usually means the cleanup doesn't happen. Simplify makes it a one-command step after implementation — run it, review the diff, and you're done.
+      Some packages are best understood as infrastructure rather than headline features. Extension Settings is one of those. It is included because it makes Powerbar configurable out of the box and provides a cleaner foundation for any future LazyPi extensions that expose settings.
     </p>
 
     <h2>Commands</h2>
@@ -102,36 +101,24 @@
       </thead>
       <tbody>
         <tr>
-          <td><code>/simplify</code></td>
-          <td>Review all uncommitted changes</td>
-        </tr>
-        <tr>
-          <td><code>/simplify --staged</code></td>
-          <td>Review only staged changes</td>
-        </tr>
-        <tr>
-          <td><code>/simplify src/foo.ts src/bar.ts</code></td>
-          <td>Review specific files</td>
-        </tr>
-        <tr>
-          <td><code>/simplify --ref=main</code></td>
-          <td>Diff against a specific branch and review those changes</td>
+          <td><code>/extension-settings</code></td>
+          <td>Open the shared settings UI for installed extensions</td>
         </tr>
       </tbody>
     </table>
 
     <div class="learn-more">
-      <a href="https://github.com/MattDevy/pi-extensions" target="_blank" rel="noopener">→ GitHub — MattDevy/pi-extensions</a>
+      <a href="https://github.com/juanibiapina/pi-extension-settings" target="_blank" rel="noopener">→ GitHub — juanibiapina/pi-extension-settings</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/plan.html" class="prev-next-link">
+      <a href="/docs/packages/powerbar.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Plan
+        ← Powerbar
       </a>
-      <a href="/docs/packages/add-dir.html" class="prev-next-link next">
+      <a href="/docs/packages/usage.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Add Directory →
+        Usage Tracker →
       </a>
     </nav>
 

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Packages — LazyPi Docs</title>
-  <meta name="description" content="All 25 packages included in LazyPi.">
+  <meta name="description" content="The 20 non-theme packages included in LazyPi, with themes documented separately.">
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -65,8 +65,11 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
@@ -78,7 +81,7 @@
 
   <main class="docs-content">
     <h1>Packages</h1>
-    <p class="page-desc">25 hand-picked packages from the Pi community. Install all of them or pick exactly what you want.</p>
+    <p class="page-desc">20 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">
@@ -126,15 +129,30 @@
         <div class="pkg-name">Prompt Templates</div>
         <div class="pkg-desc">Add model, skill, and thinking frontmatter so prompt templates switch modes automatically</div>
       </a>
+      <a class="pkg-card" href="/docs/packages/plannotator.html">
+        <span class="pkg-tag ui">ui</span>
+        <div class="pkg-name">Plannotator</div>
+        <div class="pkg-desc">Visual plan review, diff review, and markdown annotation through a local browser UI</div>
+      </a>
       <a class="pkg-card" href="/docs/packages/powerbar.html">
         <span class="pkg-tag ui">ui</span>
         <div class="pkg-name">Powerbar</div>
         <div class="pkg-desc">Persistent powerline-style status bar with git branch, token counts, and cost</div>
       </a>
+      <a class="pkg-card" href="/docs/packages/extension-settings.html">
+        <span class="pkg-tag ui">ui</span>
+        <div class="pkg-name">Extension Settings</div>
+        <div class="pkg-desc">Shared settings UI and storage layer for configurable Pi extensions</div>
+      </a>
       <a class="pkg-card" href="/docs/packages/usage.html">
         <span class="pkg-tag ui">ui</span>
         <div class="pkg-name">Usage Tracker</div>
         <div class="pkg-desc">Dashboard showing cost, tokens, and message counts by model and time period</div>
+      </a>
+      <a class="pkg-card" href="/docs/packages/raw-paste.html">
+        <span class="pkg-tag ui">ui</span>
+        <div class="pkg-name">Raw Paste</div>
+        <div class="pkg-desc">One-shot raw clipboard paste so large pasted text stays fully editable in Pi</div>
       </a>
       <a class="pkg-card" href="/docs/packages/todo.html">
         <span class="pkg-tag ui">ui</span>

--- a/docs/docs/packages/interactive-shell.html
+++ b/docs/docs/packages/interactive-shell.html
@@ -49,8 +49,11 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link active">Interactive Shell</a>

--- a/docs/docs/packages/mcp-adapter.html
+++ b/docs/docs/packages/mcp-adapter.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/memory.html
+++ b/docs/docs/packages/memory.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/plan.html
+++ b/docs/docs/packages/plan.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/plannotator.html
+++ b/docs/docs/packages/plannotator.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Simplify — LazyPi Docs</title>
+  <title>Plannotator — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -60,11 +60,10 @@
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
-      <a href="/docs/packages/simplify.html" class="sidebar-link active">Simplify</a>
+      <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
-      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link active">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -79,20 +78,20 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Simplify</h1>
-    <p class="page-desc">Reviews recently changed code for clarity, consistency, and maintainability — never changes behavior.</p>
+    <h1>Plannotator</h1>
+    <p class="page-desc">Visual plan review, diff review, and markdown annotation for Pi through a local browser UI.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-simplify reads every file that changed in your working tree, applies clarity and consistency improvements one at a time, then runs your test suite after each change to verify nothing broke. It operates on a strict constraint: it may only improve how the code reads, never what it does.
+      Plannotator adds a file-based planning workflow to Pi. Instead of keeping a plan trapped inside the chat buffer, the agent writes it to disk as markdown, then opens a browser UI where you can highlight text, leave comments, request changes, and explicitly approve the plan before execution continues.
     </p>
     <p>
-      This means simplify is safe to run after any implementation pass. It won't introduce regressions because it won't change logic. What it will do is catch naming inconsistencies, overly complex expressions, unnecessary nesting, and other readability issues that are easy to miss when you're focused on getting the feature to work.
+      It also includes the same browser workflow for reviewing git diffs and annotating markdown files or the agent's last response. That makes it especially good for long plans, code review, design feedback, and any situation where inline annotation is easier than writing free-form chat feedback.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Implementation and cleanup are cognitively different tasks. Trying to do both at once usually means the cleanup doesn't happen. Simplify makes it a one-command step after implementation — run it, review the diff, and you're done.
+      LazyPi already ships Pi's lightweight terminal-first workflow. Plannotator complements that by giving you a higher-bandwidth review surface when a task is too big or too visual for raw chat. It is one of the clearest ways to stay in control of larger agent-driven changes without giving up the speed of Pi.
     </p>
 
     <h2>Commands</h2>
@@ -102,36 +101,41 @@
       </thead>
       <tbody>
         <tr>
-          <td><code>/simplify</code></td>
-          <td>Review all uncommitted changes</td>
+          <td><code>/plannotator</code></td>
+          <td>Toggle Plannotator's plan mode for the current session</td>
         </tr>
         <tr>
-          <td><code>/simplify --staged</code></td>
-          <td>Review only staged changes</td>
+          <td><code>/plannotator-review</code></td>
+          <td>Open the current git diff in Plannotator's browser review UI</td>
         </tr>
         <tr>
-          <td><code>/simplify src/foo.ts src/bar.ts</code></td>
-          <td>Review specific files</td>
+          <td><code>/plannotator-annotate &lt;file&gt;</code></td>
+          <td>Open a markdown file for inline annotation and structured feedback</td>
         </tr>
         <tr>
-          <td><code>/simplify --ref=main</code></td>
-          <td>Diff against a specific branch and review those changes</td>
+          <td><code>/plannotator-last</code></td>
+          <td>Annotate the assistant's most recent response in the same UI</td>
         </tr>
       </tbody>
     </table>
 
+    <p>
+      You can also start Pi in plan mode directly with <code>pi --plan</code>. Plannotator then gates execution until the plan is reviewed and approved.
+    </p>
+
     <div class="learn-more">
-      <a href="https://github.com/MattDevy/pi-extensions" target="_blank" rel="noopener">→ GitHub — MattDevy/pi-extensions</a>
+      <a href="https://plannotator.ai/blog/plannotator-meets-pi/" target="_blank" rel="noopener">→ Plannotator Meets Pi</a>
+      <a href="https://github.com/backnotprop/plannotator/tree/main/apps/pi-extension" target="_blank" rel="noopener">→ GitHub — backnotprop/plannotator</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/plan.html" class="prev-next-link">
+      <a href="/docs/packages/prompt-templates.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Plan
+        ← Prompt Templates
       </a>
-      <a href="/docs/packages/add-dir.html" class="prev-next-link next">
+      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Add Directory →
+        Powerbar →
       </a>
     </nav>
 

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -63,8 +63,11 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link active">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -63,8 +63,11 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link active">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/raw-paste.html
+++ b/docs/docs/packages/raw-paste.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Simplify — LazyPi Docs</title>
+  <title>Raw Paste — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -60,15 +60,14 @@
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
-      <a href="/docs/packages/simplify.html" class="sidebar-link active">Simplify</a>
+      <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
-      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link active">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>
@@ -79,20 +78,20 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Simplify</h1>
-    <p class="page-desc">Reviews recently changed code for clarity, consistency, and maintainability — never changes behavior.</p>
+    <h1>Raw Paste</h1>
+    <p class="page-desc">One-shot raw clipboard paste so large pasted text stays fully editable in Pi.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-simplify reads every file that changed in your working tree, applies clarity and consistency improvements one at a time, then runs your test suite after each change to verify nothing broke. It operates on a strict constraint: it may only improve how the code reads, never what it does.
+      Raw Paste adds a simple <code>/paste</code> workflow for moments when you want Pi to insert clipboard content exactly as-is. Instead of condensing the paste into Pi's usual summarized marker format, the next paste is inserted raw so you can edit it directly in the composer.
     </p>
     <p>
-      This means simplify is safe to run after any implementation pass. It won't introduce regressions because it won't change logic. What it will do is catch naming inconsistencies, overly complex expressions, unnecessary nesting, and other readability issues that are easy to miss when you're focused on getting the feature to work.
+      That is especially useful for long prompts, stack traces, configs, logs, markdown drafts, or any clipboard content you want to tweak before sending. It keeps the pasted text visible and editable instead of immediately abstracting it away.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Implementation and cleanup are cognitively different tasks. Trying to do both at once usually means the cleanup doesn't happen. Simplify makes it a one-command step after implementation — run it, review the diff, and you're done.
+      LazyPi aims to remove small but recurring frictions from real-world agent workflows. Raw Paste is tiny, but it solves a surprisingly common annoyance: sometimes you do not want clever paste handling, you just want the exact text in front of you.
     </p>
 
     <h2>Commands</h2>
@@ -102,36 +101,24 @@
       </thead>
       <tbody>
         <tr>
-          <td><code>/simplify</code></td>
-          <td>Review all uncommitted changes</td>
-        </tr>
-        <tr>
-          <td><code>/simplify --staged</code></td>
-          <td>Review only staged changes</td>
-        </tr>
-        <tr>
-          <td><code>/simplify src/foo.ts src/bar.ts</code></td>
-          <td>Review specific files</td>
-        </tr>
-        <tr>
-          <td><code>/simplify --ref=main</code></td>
-          <td>Diff against a specific branch and review those changes</td>
+          <td><code>/paste</code></td>
+          <td>Arm the next clipboard paste so it is inserted raw and stays editable</td>
         </tr>
       </tbody>
     </table>
 
     <div class="learn-more">
-      <a href="https://github.com/MattDevy/pi-extensions" target="_blank" rel="noopener">→ GitHub — MattDevy/pi-extensions</a>
+      <a href="https://github.com/tmustier/pi-extensions" target="_blank" rel="noopener">→ GitHub — tmustier/pi-extensions</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/plan.html" class="prev-next-link">
+      <a href="/docs/packages/usage.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Plan
+        ← Usage Tracker
       </a>
-      <a href="/docs/packages/add-dir.html" class="prev-next-link next">
+      <a href="/docs/packages/todo.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Add Directory →
+        Todo List →
       </a>
     </nav>
 

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link active">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link active">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -64,8 +64,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -66,8 +66,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -66,8 +66,11 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
+      <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
+      <a href="/docs/packages/raw-paste.html" class="sidebar-link">Raw Paste</a>
       <a href="/docs/packages/todo.html" class="sidebar-link">Todo List</a>
       <a href="/docs/packages/btw.html" class="sidebar-link">BTW</a>
       <a href="/docs/packages/interactive-shell.html" class="sidebar-link">Interactive Shell</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -810,6 +810,12 @@
         <div class="catalog-desc">Connect Pi to any MCP-compatible tool server</div>
         <div class="catalog-author">by nicobailon</div>
       </a>
+      <a class="catalog-card" href="https://github.com/nicobailon/pi-web-access" target="_blank" rel="noopener">
+        <span class="catalog-tag core">core</span>
+        <div class="catalog-name">pi-web-access</div>
+        <div class="catalog-desc">Web search and URL fetching inside Pi</div>
+        <div class="catalog-author">by nicobailon</div>
+      </a>
       <a class="catalog-card" href="https://github.com/VandeeFeng/pi-memory-md" target="_blank" rel="noopener">
         <span class="catalog-tag core">core</span>
         <div class="catalog-name">pi-memory-md</div>
@@ -834,16 +840,46 @@
         <div class="catalog-desc">Reviews recently changed code for clarity and consistency</div>
         <div class="catalog-author">by MattDevy</div>
       </a>
+      <a class="catalog-card" href="https://github.com/itisbryan/pi-add-dir" target="_blank" rel="noopener">
+        <span class="catalog-tag core">core</span>
+        <div class="catalog-name">pi-add-dir</div>
+        <div class="catalog-desc">Load extra project directories into the current Pi session</div>
+        <div class="catalog-author">by itisbryan</div>
+      </a>
+      <a class="catalog-card" href="https://github.com/nicobailon/pi-prompt-template-model" target="_blank" rel="noopener">
+        <span class="catalog-tag core">core</span>
+        <div class="catalog-name">pi-prompt-template-model</div>
+        <div class="catalog-desc">Prompt templates with model, skill, and thinking frontmatter</div>
+        <div class="catalog-author">by nicobailon</div>
+      </a>
+      <a class="catalog-card" href="https://github.com/backnotprop/plannotator/tree/main/apps/pi-extension" target="_blank" rel="noopener">
+        <span class="catalog-tag ui">ui</span>
+        <div class="catalog-name">@plannotator/pi-extension</div>
+        <div class="catalog-desc">Visual plan review, diff review, and markdown annotation</div>
+        <div class="catalog-author">by backnotprop</div>
+      </a>
       <a class="catalog-card" href="https://github.com/juanibiapina/pi-powerbar" target="_blank" rel="noopener">
         <span class="catalog-tag ui">ui</span>
         <div class="catalog-name">pi-powerbar</div>
         <div class="catalog-desc">Status line for Pi with live context</div>
         <div class="catalog-author">by juanibiapina</div>
       </a>
+      <a class="catalog-card" href="https://github.com/juanibiapina/pi-extension-settings" target="_blank" rel="noopener">
+        <span class="catalog-tag ui">ui</span>
+        <div class="catalog-name">pi-extension-settings</div>
+        <div class="catalog-desc">Shared settings UI and storage layer for other Pi extensions</div>
+        <div class="catalog-author">by juanibiapina</div>
+      </a>
       <a class="catalog-card" href="https://github.com/tmustier/pi-extensions" target="_blank" rel="noopener">
         <span class="catalog-tag ui">ui</span>
         <div class="catalog-name">pi-usage-extension</div>
         <div class="catalog-desc">Track token usage and API cost in-session</div>
+        <div class="catalog-author">by tmustier</div>
+      </a>
+      <a class="catalog-card" href="https://github.com/tmustier/pi-extensions/tree/main/raw-paste" target="_blank" rel="noopener">
+        <span class="catalog-tag ui">ui</span>
+        <div class="catalog-name">@tmustier/pi-raw-paste</div>
+        <div class="catalog-desc">One-shot raw clipboard paste that stays fully editable</div>
         <div class="catalog-author">by tmustier</div>
       </a>
       <a class="catalog-card" href="https://github.com/tintinweb/pi-manage-todo-list" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary

LazyPi's package docs now cover the full non-theme bundle instead of leaving several shipped extensions undocumented or hard to discover. The docs index, package catalog, and package sidebar now agree on what ships, and the missing package pages explain what those extensions do in the LazyPi stack.

## What changed

- Added package docs for Plannotator, Extension Settings, and Raw Paste, including their purpose, commands, and upstream references.
- Added the missing packages to the docs package index, the shared package sidebar, and the homepage catalog so every documented package is reachable from the same navigation surfaces.
- Corrected the package-count copy to describe the 20 non-theme packages and point readers to the separate Themes page for the 5 bundled theme packages.

Adding the pages and the navigation fixes together keeps the docs internally consistent. Shipping only one side of that change would still leave users with missing entries or dead-end discovery paths.

Closes #16.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
