### PR TITLE
Migrate Compound to upstream CE3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
@@ -28,141 +27,8 @@ jobs:
       - name: Install pi
         run: npm install -g @mariozechner/pi-coding-agent
 
-      - name: Install npm dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Run lazypi --yes
-        run: node bin/lazypi.mjs --yes
-
-      - name: Assert settings.json exists
-        run: test -f ~/.pi/agent/settings.json
-
-      - name: Assert expected packages installed
-        run: |
-          node - <<'EOF'
-          const fs = require("fs");
-          const settings = JSON.parse(fs.readFileSync(`${process.env.HOME}/.pi/agent/settings.json`, "utf8"));
-          const sources = new Set((settings.packages ?? []).map(p => typeof p === "string" ? p : p.source));
-
-          const expected = [
-            "npm:pi-subagents",
-            "npm:pi-mcp-adapter",
-            "npm:pi-web-access",
-            "npm:pi-memory-md",
-            "npm:@plannotator/pi-extension",
-            "npm:@juanibiapina/pi-powerbar",
-            "npm:@tmustier/pi-usage-extension",
-            "npm:@tmustier/pi-raw-paste",
-            "npm:pi-interactive-shell",
-            "npm:@tmustier/pi-ralph-wiggum",
-            "npm:pi-btw",
-            "npm:@devkade/pi-plan",
-            "npm:pi-simplify",
-            "npm:pi-add-dir",
-            "npm:pi-prompt-template-model",
-            "npm:pi-themes",
-            "npm:pi-cyber-ui",
-            "npm:@victor-software-house/pi-curated-themes",
-            "npm:pi-terminal-theme",
-          ];
-
-          const missing = expected.filter(s => !sources.has(s));
-          if (missing.length) {
-            console.error("Missing packages in settings.json:");
-            missing.forEach(s => console.error(" -", s));
-            process.exit(1);
-          }
-
-          if (sources.has("npm:@every-env/compound-plugin")) {
-            console.error("Official Compound Engineering should not be recorded in settings.json because it is managed via bunx output files.");
-            process.exit(1);
-          }
-
-          console.log(`All ${expected.length} expected Pi packages found in settings.json.`);
-          EOF
-
-      - name: Assert official Compound Engineering installed
-        run: |
-          test -f ~/.pi/agent/.lazypi/compound-engineering.json
-          test -f ~/.pi/agent/extensions/compound-engineering-compat.ts
-          test -f ~/.pi/agent/skills/ce-plan/SKILL.md
-          grep -q '"source": "npm:@every-env/compound-plugin"' ~/.pi/agent/.lazypi/compound-engineering.json
-          grep -q '^name: ce-plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
-          ! grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
-          grep -q 'name: "ce_subagent"' ~/.pi/agent/extensions/compound-engineering-compat.ts
-          grep -q 'Claude Task(agent, args) maps to the ce_subagent extension tool' ~/.pi/agent/AGENTS.md
-          grep -q 'Run ce_subagent with agent="repo-research-analyst"' ~/.pi/agent/skills/ce-plan/SKILL.md
-
-      - name: Rerun repairs existing Compound skill names
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-          path = Path.home() / ".pi" / "agent" / "skills" / "ce-plan" / "SKILL.md"
-          text = path.read_text()
-          path.write_text(text.replace("name: ce-plan", "name: ce:plan", 1))
-          PY
-          grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
-          node bin/lazypi.mjs --yes
-          grep -q '^name: ce-plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
-          ! grep -q '^name: ce:plan$' ~/.pi/agent/skills/ce-plan/SKILL.md
-          node bin/lazypi.mjs doctor
-
-      - name: Assert CE compat tool preserves skill delegation semantics
-        run: |
-          TMPDIR=$(mktemp -d)
-          mkdir -p "$TMPDIR/proj"
-          cd "$TMPDIR/proj"
-          node "$GITHUB_WORKSPACE/bin/lazypi.mjs" --yes --only compound -l
-          node - <<'EOF'
-          const fs = require('fs');
-          const source = fs.readFileSync('.pi/extensions/compound-engineering-compat.ts', 'utf8');
-          if (!source.includes('name: "ce_subagent"')) {
-            throw new Error('ce_subagent tool registration missing');
-          }
-          if (!source.includes('const prompt = "/skill:" + agent + " " + taskText')) {
-            throw new Error('ce_subagent no longer delegates via /skill:<agent>');
-          }
-          if (!source.includes('const script = "cd " + shellEscape(cwd) + " && pi --no-session -p " + shellEscape(prompt)')) {
-            throw new Error('ce_subagent no longer shells out through pi --no-session -p');
-          }
-          console.log('verified ce_subagent preserves /skill-based delegation semantics');
-          EOF
-
-      - name: Doctor warns when auth missing but succeeds
-        run: |
-          set -euo pipefail
-          AUTH_PATH="$HOME/.pi/agent/auth.json"
-          BACKUP_PATH="$HOME/.pi/agent/auth.json.lazypi-test-backup"
-          cleanup() {
-            if [ -f "$BACKUP_PATH" ]; then mv "$BACKUP_PATH" "$AUTH_PATH"; fi
-          }
-          trap cleanup EXIT
-          if [ -f "$AUTH_PATH" ]; then mv "$AUTH_PATH" "$BACKUP_PATH"; fi
-          env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY -u GOOGLE_API_KEY -u GEMINI_API_KEY -u OPENROUTER_API_KEY -u TOGETHER_API_KEY -u GROQ_API_KEY -u MISTRAL_API_KEY \
-            node bin/lazypi.mjs doctor >/tmp/lazypi-doctor-no-auth.log 2>&1
-          grep -q 'No credentials detected — run `pi` then `/login`, or export a provider API key' /tmp/lazypi-doctor-no-auth.log
-          grep -q '1 warning(s) found\.' /tmp/lazypi-doctor-no-auth.log
-
-      - name: Doctor warns when bun missing
-        run: |
-          FILTERED_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '/.bun/bin' | paste -sd ':' -)
-          PATH="$FILTERED_PATH" node bin/lazypi.mjs doctor >/tmp/lazypi-doctor-no-bun.log 2>&1 || true
-          grep -q 'bun is not on PATH — official Compound Engineering from Every will be skipped by LazyPi' /tmp/lazypi-doctor-no-bun.log
-
-      - name: Compound-only install patches compat extension without requiring pi-subagents
-        run: |
-          TMPDIR=$(mktemp -d)
-          mkdir -p "$TMPDIR/proj"
-          cd "$TMPDIR/proj"
-          node "$GITHUB_WORKSPACE/bin/lazypi.mjs" --yes --only compound -l
-          test ! -f .pi/settings.json || ! grep -q 'npm:pi-subagents' .pi/settings.json
-          grep -q 'name: "ce_subagent"' .pi/extensions/compound-engineering-compat.ts
-
-      - name: Remove official Compound Engineering
-        run: node bin/lazypi.mjs remove compound
-
-      - name: Assert official Compound Engineering removed cleanly
-        run: |
-          test ! -e ~/.pi/agent/.lazypi/compound-engineering.json
-          test ! -e ~/.pi/agent/extensions/compound-engineering-compat.ts
-          test ! -d ~/.pi/agent/skills/ce-plan
+      - name: Run test suite
+        run: npm test

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { argv, cwd, exit, stdout, stderr } from "node:process";
 import {
@@ -26,6 +26,7 @@ const CATEGORIES = ["core", "ui", "research", "frameworks", "themes"];
 
 const PACKAGES = [
 	{ id: "subagents", category: "core", source: "npm:pi-subagents", description: "Sub-agent execution", hint: "Run isolated sub-agents for parallel work." },
+	{ id: "pi-ask-user", category: "core", source: "npm:pi-ask-user", description: "Ask-user prompts", hint: "Interactive user questions for agent workflows." },
 	{ id: "mcp", category: "core", source: "npm:pi-mcp-adapter", description: "MCP server integration", hint: "Connect Pi to any MCP-compatible tool server." },
 	{ id: "web-access", category: "core", source: "npm:pi-web-access", description: "Web search and page fetch", hint: "Built-in web search and URL fetching." },
 	{ id: "memory", category: "core", source: "npm:pi-memory-md", description: "Markdown-backed memory", hint: "Persistent memory stored as Markdown files." },
@@ -61,11 +62,12 @@ const PACKAGES = [
 
 const COMPOUND_PKG_ID = "compound";
 const COMPOUND_SOURCE = "npm:@every-env/compound-plugin";
+const COMPOUND_UPSTREAM_PACKAGE = "@every-env/compound-plugin@3.0.0";
 const COMPOUND_PLUGIN_NAME = "compound-engineering";
-const COMPOUND_STATE_VERSION = 1;
-const COMPOUND_MANAGED_RELATIVE_PATHS = ["AGENTS.md", "prompts", "skills", "extensions", "compound-engineering"];
-const COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH = join("extensions", "compound-engineering-compat.ts");
-const COMPOUND_SUBAGENT_TOOL_NAME = "ce_subagent";
+const COMPOUND_DEPENDENCY_IDS = ["subagents", "pi-ask-user"];
+const COMPOUND_MANIFEST_RELATIVE_PATH = join("compound-engineering", "install-manifest.json");
+const COMPOUND_LEGACY_STATE_RELATIVE_PATH = join(".lazypi", "compound-engineering.json");
+const PACKAGE_DEPENDENCIES = new Map([[COMPOUND_PKG_ID, COMPOUND_DEPENDENCY_IDS]]);
 
 // ---------------------------------------------------------------------------
 // Output helpers
@@ -180,6 +182,23 @@ function resolveSelection(flags) {
 		return new Set(PACKAGES.filter((p) => !matchesSelector(p, flags.except)).map((p) => p.id));
 	}
 	return new Set(PACKAGES.map((p) => p.id));
+}
+
+function expandPackageDependencies(selectedIds) {
+	const expanded = new Set(selectedIds);
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const [pkgId, dependencyIds] of PACKAGE_DEPENDENCIES.entries()) {
+			if (!expanded.has(pkgId)) continue;
+			for (const dependencyId of dependencyIds) {
+				if (expanded.has(dependencyId)) continue;
+				expanded.add(dependencyId);
+				changed = true;
+			}
+		}
+	}
+	return expanded;
 }
 
 // ---------------------------------------------------------------------------
@@ -324,12 +343,7 @@ function compoundInstallRoot(local) {
 	return local ? join(cwd(), ".pi") : join(homedir(), ".pi", "agent");
 }
 
-function compoundStatePath(local) {
-	return join(compoundInstallRoot(local), ".lazypi", "compound-engineering.json");
-}
-
-function readCompoundState(local) {
-	const path = compoundStatePath(local);
+function readJsonFileWithMetadata(path) {
 	if (!existsSync(path)) return { path, exists: false, parsed: null, error: null };
 	try {
 		return { path, exists: true, parsed: JSON.parse(readFileSync(path, "utf8")), error: null };
@@ -338,47 +352,54 @@ function readCompoundState(local) {
 	}
 }
 
-function writeCompoundState(local, state) {
-	const path = compoundStatePath(local);
-	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, JSON.stringify(state, null, 2) + "\n", "utf8");
-	return path;
+function compoundManifestPath(local) {
+	return join(compoundInstallRoot(local), COMPOUND_MANIFEST_RELATIVE_PATH);
 }
 
-function clearCompoundState(local) {
-	const path = compoundStatePath(local);
+function readCompoundManifest(local) {
+	return readJsonFileWithMetadata(compoundManifestPath(local));
+}
+
+function compoundLegacyStatePath(local) {
+	return join(compoundInstallRoot(local), COMPOUND_LEGACY_STATE_RELATIVE_PATH);
+}
+
+function readCompoundLegacyState(local) {
+	return readJsonFileWithMetadata(compoundLegacyStatePath(local));
+}
+
+function clearCompoundLegacyState(local) {
+	const path = compoundLegacyStatePath(local);
 	if (existsSync(path)) rmSync(path, { force: true });
 	const parent = dirname(path);
 	if (existsSync(parent) && readdirSync(parent).length === 0) rmSync(parent, { recursive: true, force: true });
 }
 
+function compoundInstallState(local) {
+	const manifest = readCompoundManifest(local);
+	const legacy = readCompoundLegacyState(local);
+	if (manifest.exists) {
+		if (manifest.error) return { mode: "invalid-manifest", manifest, legacy };
+		if (manifest.parsed) return { mode: "manifest", manifest, legacy };
+	}
+	if (legacy.exists) {
+		if (legacy.error) return { mode: "invalid-legacy", manifest, legacy };
+		if (legacy.parsed) return { mode: "legacy", manifest, legacy };
+	}
+	return { mode: "none", manifest, legacy };
+}
+
 function isCompoundInstalled(local) {
-	const state = readCompoundState(local);
-	return Boolean(state.exists && !state.error && state.parsed);
+	const { mode } = compoundInstallState(local);
+	return mode === "manifest" || mode === "legacy";
+}
+
+function compoundNeedsMigration(local) {
+	return compoundInstallState(local).mode === "legacy";
 }
 
 function normalizeRelativePath(path) {
-	return path.split("\\").join("/");
-}
-
-function collectManagedFiles(root, relativePath, files) {
-	const absolutePath = join(root, relativePath);
-	if (!existsSync(absolutePath)) return;
-	const stats = statSync(absolutePath);
-	if (stats.isFile()) {
-		files.set(normalizeRelativePath(relative(root, absolutePath)), readFileSync(absolutePath).toString("base64"));
-		return;
-	}
-	for (const name of readdirSync(absolutePath)) {
-		collectManagedFiles(root, join(relativePath, name), files);
-	}
-}
-
-function snapshotCompoundManagedFiles(local) {
-	const root = resolve(compoundInstallRoot(local));
-	const files = new Map();
-	for (const relativePath of COMPOUND_MANAGED_RELATIVE_PATHS) collectManagedFiles(root, relativePath, files);
-	return { root, files };
+	return path.split("\\").join("/").replace(/^\.\//, "");
 }
 
 function pruneEmptyDirs(path) {
@@ -389,138 +410,70 @@ function pruneEmptyDirs(path) {
 
 function removeEmptyManagedDirs(local) {
 	const root = compoundInstallRoot(local);
-	for (const dir of ["prompts", "skills", "extensions", "compound-engineering", ".lazypi"]) pruneEmptyDirs(join(root, dir));
-}
-
-function compoundCompatExtensionPath(local) {
-	return join(compoundInstallRoot(local), COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH);
-}
-
-function patchCompoundCompatExtension(local) {
-	const path = compoundCompatExtensionPath(local);
-	if (!existsSync(path)) return { ok: false, reason: `missing ${COMPOUND_COMPAT_EXTENSION_RELATIVE_PATH}` };
-	const original = readFileSync(path, "utf8");
-	if (original.includes(`name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`)) return { ok: true, patched: false, path };
-	let patched = original;
-	patched = patched.replace('name: "subagent"', `name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`);
-	patched = patched.replace('label: "Subagent"', 'label: "CE Subagent"');
-	patched = patched.replace('description: "Run one or more skill-based subagent tasks. Supports single, parallel, and chained execution."', 'description: "Run one or more Compound Engineering skill-based subagent tasks. Supports single, parallel, and chained execution."');
-	if (patched === original || patched.includes('name: "subagent"')) {
-		return { ok: false, reason: `could not rename subagent tool to ${COMPOUND_SUBAGENT_TOOL_NAME}` };
+	for (const dir of ["prompts", "skills", "extensions", "agents", "compound-engineering", ".lazypi"]) {
+		pruneEmptyDirs(join(root, dir));
 	}
-	writeFileSync(path, patched, "utf8");
-	return { ok: true, patched: true, path };
 }
 
-function patchCompoundTextFile(path, replacements) {
-	if (!existsSync(path)) return;
-	const original = readFileSync(path, "utf8");
-	let next = original;
-	for (const [pattern, replacement] of replacements) next = next.replace(pattern, replacement);
-	if (next !== original) writeFileSync(path, next, "utf8");
-}
-
-function listCompoundSkillNameConflicts(local) {
-	const root = compoundInstallRoot(local);
-	const skillsRoot = join(root, "skills");
-	if (!existsSync(skillsRoot)) return [];
-	const conflicts = [];
-	for (const entry of readdirSync(skillsRoot)) {
-		const skillDir = join(skillsRoot, entry);
-		if (!statSync(skillDir).isDirectory()) continue;
-		const skillFile = join(skillDir, "SKILL.md");
-		if (!existsSync(skillFile)) continue;
-		const original = readFileSync(skillFile, "utf8");
-		const frontmatterMatch = original.match(/^---\n([\s\S]*?)\n---/);
-		if (!frontmatterMatch) continue;
-		const nameMatch = frontmatterMatch[1].match(/^name:\s*(.+)\s*$/m);
-		if (!nameMatch) continue;
-		const currentName = nameMatch[1].trim().replace(/^['"]|['"]$/g, "");
-		if (!currentName || currentName === entry) continue;
-		conflicts.push({
-			path: normalizeRelativePath(relative(root, skillFile)),
-			absolutePath: skillFile,
-			currentName,
-			expectedName: entry,
-		});
+function coerceCompoundManagedPath(entry) {
+	if (typeof entry === "string") return normalizeRelativePath(entry);
+	if (!entry || typeof entry !== "object") return null;
+	for (const key of ["path", "relativePath", "file"]) {
+		if (typeof entry[key] === "string") return normalizeRelativePath(entry[key]);
 	}
-	return conflicts;
+	return null;
 }
 
-function normalizeCompoundSkillFrontmatter(local) {
-	const conflicts = listCompoundSkillNameConflicts(local);
-	const nameMap = new Map(conflicts.map((conflict) => [conflict.currentName, conflict.expectedName]));
-	const patchedFiles = [];
-	for (const conflict of conflicts) {
-		const original = readFileSync(conflict.absolutePath, "utf8");
-		const next = original.replace(/^name:\s*.+$/m, `name: ${conflict.expectedName}`);
-		if (next === original) continue;
-		writeFileSync(conflict.absolutePath, next, "utf8");
-		patchedFiles.push(conflict.path);
-	}
-	return { nameMap, patchedFiles };
-}
-
-function patchCompoundSkillReferences(local, nameMap) {
-	if (nameMap.size === 0) return [];
-	const root = compoundInstallRoot(local);
-	const replacements = [...nameMap.entries()].sort((a, b) => b[0].length - a[0].length);
-	const patchedFiles = [];
-	const visit = (relativePath) => {
-		const absolutePath = join(root, relativePath);
-		if (!existsSync(absolutePath)) return;
-		const stats = statSync(absolutePath);
-		if (stats.isDirectory()) {
-			for (const name of readdirSync(absolutePath)) visit(join(relativePath, name));
+function compoundManifestManagedPaths(manifest) {
+	const seen = new Set(["AGENTS.md"]);
+	const add = (entry, baseDir = null) => {
+		const path = coerceCompoundManagedPath(entry);
+		if (path) {
+			seen.add(baseDir != null && !path.includes("/") ? normalizeRelativePath(join(baseDir, path)) : path);
 			return;
 		}
-		if (!/\.(md|json|ts|ya?ml|txt|sh)$/i.test(relativePath)) return;
-		const original = readFileSync(absolutePath, "utf8");
-		let next = original;
-		for (const [oldName, newName] of replacements) next = next.split(oldName).join(newName);
-		if (next === original) return;
-		writeFileSync(absolutePath, next, "utf8");
-		patchedFiles.push(normalizeRelativePath(relative(root, absolutePath)));
+		if (typeof entry === "string" && baseDir != null) seen.add(normalizeRelativePath(join(baseDir, entry)));
 	};
-	for (const relativePath of COMPOUND_MANAGED_RELATIVE_PATHS) visit(relativePath);
-	return patchedFiles;
+	for (const source of [manifest, manifest?.installManifest]) {
+		if (!source || typeof source !== "object") continue;
+		for (const key of ["files", "managedFiles", "paths", "createdFiles", "artifacts"]) {
+			if (!Array.isArray(source[key])) continue;
+			for (const entry of source[key]) add(entry);
+		}
+		for (const entry of source.skills ?? []) add(entry, "skills");
+		for (const entry of source.prompts ?? []) add(entry, "prompts");
+		for (const entry of source.extensions ?? []) add(entry, "extensions");
+		for (const entry of source.agents ?? []) add(entry, "agents");
+	}
+	return [...seen].sort((a, b) => b.length - a.length);
 }
 
-function patchCompoundGeneratedContent(local) {
-	const root = compoundInstallRoot(local);
-	patchCompoundTextFile(join(root, "AGENTS.md"), [
-		[/\bsubagent extension tool\b/g, `${COMPOUND_SUBAGENT_TOOL_NAME} extension tool`],
-		[/\bmulti_tool_use\.parallel\b/g, `${COMPOUND_SUBAGENT_TOOL_NAME} in parallel mode`],
-	]);
-	patchCompoundTextFile(join(root, "skills", "ce-plan", "SKILL.md"), [
-		[/Run subagent with/g, `Run ${COMPOUND_SUBAGENT_TOOL_NAME} with`],
-	]);
-	patchCompoundTextFile(join(root, "skills", "document-review", "SKILL.md"), [
-		[/Dispatch all agents in \*\*parallel\*\* using the platform's task\/agent tool/g, `Dispatch all agents in **parallel** using the \`${COMPOUND_SUBAGENT_TOOL_NAME}\` tool`],
-	]);
-	patchCompoundTextFile(join(root, "skills", "ce-review", "SKILL.md"), [
-		[/Omit the `mode` parameter when dispatching sub-agents/g, `Omit the \`mode\` parameter when dispatching with \`${COMPOUND_SUBAGENT_TOOL_NAME}\``],
-		[/Spawn each selected persona reviewer as a parallel sub-agent/g, `Spawn each selected persona reviewer with \`${COMPOUND_SUBAGENT_TOOL_NAME}\` in parallel`],
-	]);
-	patchCompoundTextFile(join(root, "skills", "ce-optimize", "SKILL.md"), [
-		[/Dispatch a subagent with the filled prompt/g, `Dispatch ${COMPOUND_SUBAGENT_TOOL_NAME} with the filled prompt`],
-		[/fall back to subagent/g, `fall back to ${COMPOUND_SUBAGENT_TOOL_NAME}`],
-	]);
-	patchCompoundTextFile(join(root, "skills", "ce-compound-refresh", "SKILL.md"), [
-		[/When spawning any subagent/g, `When spawning any subagent via \`${COMPOUND_SUBAGENT_TOOL_NAME}\``],
-	]);
-	const { nameMap } = normalizeCompoundSkillFrontmatter(local);
-	patchCompoundSkillReferences(local, nameMap);
+function legacyCompoundCreatedPaths(state) {
+	return [...new Set((state?.createdFiles ?? []).map((path) => normalizeRelativePath(path)).filter(Boolean))].sort((a, b) => b.length - a.length);
 }
 
-function repairInstalledCompound(local) {
-	if (!isCompoundInstalled(local)) return { status: "missing" };
-	const patchResult = patchCompoundCompatExtension(local);
-	if (!patchResult.ok) return { status: "failed", code: 1, reason: patchResult.reason };
-	patchCompoundGeneratedContent(local);
-	const remainingConflicts = listCompoundSkillNameConflicts(local).length;
-	if (remainingConflicts > 0) return { status: "failed", code: 1, reason: `${remainingConflicts} skill name conflict(s) remain after repair` };
-	return { status: "repaired" };
+function removeManagedPaths(root, relativePaths) {
+	for (const relativePath of [...new Set(relativePaths.filter(Boolean))].sort((a, b) => b.length - a.length)) {
+		rmSync(join(root, relativePath), { recursive: true, force: true });
+	}
+}
+
+function restoreLegacyCompoundModifiedFiles(root, state) {
+	for (const entry of state?.modifiedFiles ?? []) {
+		if (!entry || typeof entry.path !== "string" || typeof entry.previousContentBase64 !== "string") continue;
+		const target = join(root, normalizeRelativePath(entry.path));
+		mkdirSync(dirname(target), { recursive: true });
+		writeFileSync(target, Buffer.from(entry.previousContentBase64, "base64"));
+	}
+}
+
+function runCompoundPlugin(command, local) {
+	const targetRoot = resolve(compoundInstallRoot(local));
+	mkdirSync(targetRoot, { recursive: true });
+	const args = command === "cleanup"
+		? [COMPOUND_UPSTREAM_PACKAGE, "cleanup", "--target", "pi", "--pi-home", targetRoot]
+		: [COMPOUND_UPSTREAM_PACKAGE, "install", COMPOUND_PLUGIN_NAME, "--to", "pi", "--pi-home", targetRoot];
+	return spawnSync("bunx", args, { stdio: "inherit" }).status ?? 1;
 }
 
 function installCompound(local, interactive = false) {
@@ -531,55 +484,51 @@ function installCompound(local, interactive = false) {
 		return { status: "skipped", reason };
 	}
 
-	const targetRoot = resolve(compoundInstallRoot(local));
-	mkdirSync(targetRoot, { recursive: true });
-	const before = snapshotCompoundManagedFiles(local);
-	const args = ["@every-env/compound-plugin", "install", COMPOUND_PLUGIN_NAME, "--to", "pi", "--pi-home", targetRoot];
-	const status = spawnSync("bunx", args, { stdio: "inherit" }).status ?? 1;
-	if (status !== 0) return { status: "failed", code: status };
+	const cleanupStatus = runCompoundPlugin("cleanup", local);
+	if (cleanupStatus !== 0) return { status: "failed", code: cleanupStatus, reason: "upstream cleanup failed" };
 
-	const patchResult = patchCompoundCompatExtension(local);
-	if (!patchResult.ok) return { status: "failed", code: 1, reason: patchResult.reason };
-	patchCompoundGeneratedContent(local);
+	const installStatus = runCompoundPlugin("install", local);
+	if (installStatus !== 0) return { status: "failed", code: installStatus, reason: "upstream install failed" };
 
-	const after = snapshotCompoundManagedFiles(local);
-	const createdFiles = [];
-	const modifiedFiles = [];
-	for (const [path, contentBase64] of after.files.entries()) {
-		if (!before.files.has(path)) createdFiles.push(path);
-		else if (before.files.get(path) !== contentBase64) modifiedFiles.push({ path, previousContentBase64: before.files.get(path) });
-	}
+	const manifest = readCompoundManifest(local);
+	if (manifest.error) return { status: "failed", code: 1, reason: `manifest is invalid (${manifest.error})` };
+	if (!manifest.exists || !manifest.parsed) return { status: "failed", code: 1, reason: `missing ${COMPOUND_MANIFEST_RELATIVE_PATH}` };
 
-	writeCompoundState(local, {
-		version: COMPOUND_STATE_VERSION,
-		source: COMPOUND_SOURCE,
-		root: targetRoot,
-		installedAt: new Date().toISOString(),
-		createdFiles: createdFiles.sort(),
-		modifiedFiles: modifiedFiles.sort((a, b) => a.path.localeCompare(b.path)),
-	});
-	return { status: "installed", count: createdFiles.length + modifiedFiles.length };
+	clearCompoundLegacyState(local);
+	removeEmptyManagedDirs(local);
+	return { status: "installed" };
 }
 
 function removeCompound(local) {
-	const state = readCompoundState(local);
-	if (!state.exists) return 0;
-	if (state.error || !state.parsed) {
-		console.error(red(`Compound Engineering state file is invalid: ${state.error}`));
+	const installState = compoundInstallState(local);
+	const root = resolve(compoundInstallRoot(local));
+
+	if (installState.mode === "invalid-manifest") {
+		console.error(red(`Compound Engineering manifest is invalid: ${installState.manifest.error}`));
 		return 1;
 	}
+	if (installState.mode === "invalid-legacy") {
+		console.error(red(`Compound Engineering legacy state is invalid: ${installState.legacy.error}`));
+		return 1;
+	}
+	if (installState.mode === "none") return 0;
 
-	const root = resolve(compoundInstallRoot(local));
-	const createdFiles = [...(state.parsed.createdFiles ?? [])].sort((a, b) => b.length - a.length);
-	for (const relativePath of createdFiles) rmSync(join(root, relativePath), { recursive: true, force: true });
-
-	for (const entry of state.parsed.modifiedFiles ?? []) {
-		const target = join(root, entry.path);
-		mkdirSync(dirname(target), { recursive: true });
-		writeFileSync(target, Buffer.from(entry.previousContentBase64, "base64"));
+	if (installState.mode === "manifest") {
+		const managedPaths = compoundManifestManagedPaths(installState.manifest.parsed);
+		if (managedPaths.length === 0) {
+			console.error(red(`Compound Engineering manifest does not list managed paths: ${installState.manifest.path}`));
+			return 1;
+		}
+		removeManagedPaths(root, [...managedPaths, COMPOUND_MANIFEST_RELATIVE_PATH, join("compound-engineering", "legacy-backup")]);
 	}
 
-	clearCompoundState(local);
+	if (installState.mode === "legacy") {
+		removeManagedPaths(root, legacyCompoundCreatedPaths(installState.legacy.parsed));
+		restoreLegacyCompoundModifiedFiles(root, installState.legacy.parsed);
+		removeManagedPaths(root, [join("compound-engineering", "legacy-backup")]);
+	}
+
+	clearCompoundLegacyState(local);
 	removeEmptyManagedDirs(local);
 	return 0;
 }
@@ -647,14 +596,29 @@ function findLegacyInstalledSources(pkg, installedPiSources) {
 	return [...installedPiSources].filter((source) => isLegacySourceForPackage(pkg, source));
 }
 
+function packageInstallStatus(pkg, installedPiSources, local) {
+	if (pkg.id === COMPOUND_PKG_ID) {
+		const { mode } = compoundInstallState(local);
+		return {
+			installed: mode === "manifest",
+			legacy: mode === "legacy",
+			present: mode === "manifest" || mode === "legacy",
+		};
+	}
+	const legacySources = findLegacyInstalledSources(pkg, installedPiSources);
+	return {
+		installed: installedPiSources.has(pkg.source),
+		legacy: legacySources.length > 0,
+		present: installedPiSources.has(pkg.source) || legacySources.length > 0,
+	};
+}
+
 function isPackageInstalled(pkg, installedPiSources, local) {
-	return pkg.id === COMPOUND_PKG_ID ? isCompoundInstalled(local) : installedPiSources.has(pkg.source);
+	return packageInstallStatus(pkg, installedPiSources, local).installed;
 }
 
 function isPackagePresent(pkg, installedPiSources, local) {
-	return pkg.id === COMPOUND_PKG_ID
-		? isCompoundInstalled(local)
-		: installedPiSources.has(pkg.source) || findLegacyInstalledSources(pkg, installedPiSources).length > 0;
+	return packageInstallStatus(pkg, installedPiSources, local).present;
 }
 
 // ---------------------------------------------------------------------------
@@ -800,7 +764,7 @@ async function ensurePi(flags) {
 // install
 // ---------------------------------------------------------------------------
 async function cmdInstall(flags) {
-	let selectedIds = resolveSelection(flags);
+	let selectedIds = expandPackageDependencies(resolveSelection(flags));
 
 	const usedSelectionFlag = Boolean(flags.only || flags.except);
 	const interactive = !flags.yes && !usedSelectionFlag && isInteractive();
@@ -814,7 +778,7 @@ async function cmdInstall(flags) {
 	if (interactive) {
 		const choice = await askLazyOrPick(PACKAGES.length);
 		if (choice === "pick") {
-			selectedIds = await runPicker(selectedIds);
+			selectedIds = expandPackageDependencies(await runPicker(selectedIds));
 		}
 	}
 
@@ -829,10 +793,22 @@ async function cmdInstall(flags) {
 	if (settingsError) log.warn(`Could not parse ${settingsPath(flags.local)} — ${settingsError}`);
 
 	const forceIds = new Set(Array.isArray(flags.forceIds) ? flags.forceIds : []);
-	const toInstall = selected.filter((p) => forceIds.has(p.id) || !isPackageInstalled(p, installedSources, flags.local));
-	const alreadyInstalled = selected.filter((p) => !forceIds.has(p.id) && isPackageInstalled(p, installedSources, flags.local));
-	const legacyInstalled = selected.filter((p) => !forceIds.has(p.id) && !isPackageInstalled(p, installedSources, flags.local) && isPackagePresent(p, installedSources, flags.local));
-	const installLabel = legacyInstalled.length > 0 ? `${toInstall.length} (${legacyInstalled.length} source migration${legacyInstalled.length === 1 ? "" : "s"})` : String(toInstall.length);
+	const toInstall = selected.filter((pkg) => {
+		if (forceIds.has(pkg.id)) return true;
+		if (pkg.id === COMPOUND_PKG_ID) return !isCompoundInstalled(flags.local) || compoundNeedsMigration(flags.local);
+		return !isPackageInstalled(pkg, installedSources, flags.local);
+	});
+	const alreadyInstalled = selected.filter((pkg) => {
+		if (forceIds.has(pkg.id)) return false;
+		if (pkg.id === COMPOUND_PKG_ID) return isCompoundInstalled(flags.local) && !compoundNeedsMigration(flags.local);
+		return isPackageInstalled(pkg, installedSources, flags.local);
+	});
+	const legacyInstalled = selected.filter((pkg) => {
+		if (forceIds.has(pkg.id)) return false;
+		if (pkg.id === COMPOUND_PKG_ID) return compoundNeedsMigration(flags.local);
+		return !isPackageInstalled(pkg, installedSources, flags.local) && isPackagePresent(pkg, installedSources, flags.local);
+	});
+	const installLabel = legacyInstalled.length > 0 ? `${toInstall.length} (${legacyInstalled.length} migration${legacyInstalled.length === 1 ? "" : "s"})` : String(toInstall.length);
 	const scope = flags.local ? "project (.pi/settings.json)" : "global (~/.pi/agent/settings.json)";
 
 	const preInstallAuth = detectAuth();
@@ -857,20 +833,6 @@ async function cmdInstall(flags) {
 				console.error(red(message));
 			}
 			return 2;
-		}
-	}
-
-	if (selected.some((p) => p.id === COMPOUND_PKG_ID) && isCompoundInstalled(flags.local) && !forceIds.has(COMPOUND_PKG_ID)) {
-		const repairResult = repairInstalledCompound(flags.local);
-		if (repairResult.status === "failed") {
-			const message = `Failed to repair existing Compound Engineering install${repairResult.reason ? ` (${repairResult.reason})` : ""}.`;
-			if (interactive) {
-				log.error(message);
-				outro(red("Aborted."));
-			} else {
-				console.error(red(message));
-			}
-			return repairResult.code ?? 1;
 		}
 	}
 
@@ -903,18 +865,9 @@ async function cmdInstall(flags) {
 
 	for (const pkg of toInstall) {
 		if (pkg.id === COMPOUND_PKG_ID) {
-			const action = `bunx @every-env/compound-plugin install ${COMPOUND_PLUGIN_NAME} --to pi`;
+			const action = `bunx ${COMPOUND_UPSTREAM_PACKAGE} cleanup --target pi && bunx ${COMPOUND_UPSTREAM_PACKAGE} install ${COMPOUND_PLUGIN_NAME} --to pi`;
 			if (interactive) log.step(action);
 			else console.log(`\n→ ${action}`);
-			if (forceIds.has(COMPOUND_PKG_ID) && isCompoundInstalled(flags.local)) {
-				const removeStatus = removeCompound(flags.local);
-				if (removeStatus !== 0) {
-					failed.push(pkg);
-					if (interactive) log.error(`failed to refresh ${pkg.id}`);
-					else console.error(red(`  ✗ failed to refresh ${pkg.id}`));
-					continue;
-				}
-			}
 			const result = installCompound(flags.local, interactive);
 			if (result.status === "failed") {
 				failed.push(pkg);
@@ -1055,9 +1008,9 @@ function cmdStatus(flags) {
 	}
 
 	const piCatalogSources = new Set(PACKAGES.flatMap((p) => [p.source, ...legacySourcesForPackage(p)]));
-	const installed = PACKAGES.filter((p) => isPackageInstalled(p, sources, flags.local));
-	const legacy = PACKAGES.filter((p) => !isPackageInstalled(p, sources, flags.local) && findLegacyInstalledSources(p, sources).length > 0);
-	const missing = PACKAGES.filter((p) => !isPackagePresent(p, sources, flags.local));
+	const installed = PACKAGES.filter((pkg) => packageInstallStatus(pkg, sources, flags.local).installed);
+	const legacy = PACKAGES.filter((pkg) => packageInstallStatus(pkg, sources, flags.local).legacy);
+	const missing = PACKAGES.filter((pkg) => !packageInstallStatus(pkg, sources, flags.local).present);
 	const others = [...sources].filter((src) => !piCatalogSources.has(src) && !PACKAGES.some((pkg) => isLegacySourceForPackage(pkg, src)));
 
 	printHeader(`Installed from LazyPi catalog (${installed.length}/${PACKAGES.length}):`);
@@ -1069,8 +1022,10 @@ function cmdStatus(flags) {
 	printHeader(`Installed with legacy catalog sources (${legacy.length}):`);
 	if (legacy.length === 0) console.log(dim("  none"));
 	for (const pkg of legacy) {
-		const legacySources = findLegacyInstalledSources(pkg, sources).map((src) => dim(src)).join(", ");
-		console.log(`  ${yellow("!")} [${pkg.category}] ${pkg.id.padEnd(20)} ${legacySources}`);
+		const detail = pkg.id === COMPOUND_PKG_ID
+			? dim("legacy LazyPi state detected — run `lazypi update` to migrate to CE 3")
+			: findLegacyInstalledSources(pkg, sources).map((src) => dim(src)).join(", ");
+		console.log(`  ${yellow("!")} [${pkg.category}] ${pkg.id.padEnd(20)} ${detail}`);
 	}
 
 	printHeader(`Missing from LazyPi catalog (${missing.length}):`);
@@ -1086,6 +1041,23 @@ function cmdStatus(flags) {
 	return 0;
 }
 
+function updateLocalPiPackages(local) {
+	const { sources, error } = readInstalledSources(local);
+	if (error) {
+		console.error(red(`Could not parse ${settingsPath(local)} — ${error}`));
+		return 1;
+	}
+	for (const source of sources) {
+		console.log(`\n→ pi install ${source}`);
+		const env = source.startsWith("git:")
+			? { ...process.env, npm_config_ignore_scripts: "true" }
+			: process.env;
+		const installStatus = spawnSync("pi", ["install", "-l", source], { stdio: "inherit", env }).status ?? 1;
+		if (installStatus !== 0) return installStatus;
+	}
+	return 0;
+}
+
 // ---------------------------------------------------------------------------
 // update
 // ---------------------------------------------------------------------------
@@ -1097,7 +1069,7 @@ async function cmdUpdate(flags) {
 	if (installCode !== 0) return installCode;
 
 	console.log(bold("\nStep 2/2: pi update"));
-	const piUpdateCode = runPi(flags.local ? ["update", "-l"] : ["update"]);
+	const piUpdateCode = flags.local ? updateLocalPiPackages(true) : runPi(["update"]);
 	return piUpdateCode === 0 ? repairDiffReview(flags.local, false) : piUpdateCode;
 }
 
@@ -1162,18 +1134,28 @@ function cmdDoctor(flags) {
 		console.log(`  ${dim("·")} diff-review not installed`);
 	}
 
-	const compoundState = readCompoundState(flags.local);
-	if (compoundState.error) {
-		fail(`Compound Engineering state file is invalid — ${compoundState.error}`);
-	} else if (compoundState.exists) {
-		pass(`Compound Engineering managed state found at ${compoundState.path}`);
-		const compatPath = compoundCompatExtensionPath(flags.local);
-		if (!existsSync(compatPath)) fail(`Compound Engineering compat extension is missing at ${compatPath}`);
-		else if (readFileSync(compatPath, "utf8").includes(`name: "${COMPOUND_SUBAGENT_TOOL_NAME}"`)) pass(`Compound Engineering compat tool renamed to ${COMPOUND_SUBAGENT_TOOL_NAME}`);
-		else fail(`Compound Engineering compat extension still registers the conflicting subagent tool`);
-		const skillNameConflicts = listCompoundSkillNameConflicts(flags.local);
-		if (skillNameConflicts.length === 0) pass("Compound skill names normalized to Pi's current skill spec");
-		else fail(`Compound generated skills still have ${skillNameConflicts.length} Pi-incompatible name conflict(s)`);
+	const compound = compoundInstallState(flags.local);
+	if (compound.mode === "invalid-manifest") {
+		fail(`Compound Engineering manifest is invalid — ${compound.manifest.error}`);
+	} else if (compound.mode === "invalid-legacy") {
+		fail(`Compound Engineering legacy state is invalid — ${compound.legacy.error}`);
+	} else if (compound.mode === "manifest") {
+		pass(`Compound Engineering manifest found at ${compound.manifest.path}`);
+		const compoundRoot = compoundInstallRoot(flags.local);
+		const skillsDir = join(compoundRoot, "skills");
+		const agentsDir = join(compoundRoot, "agents");
+		if (existsSync(skillsDir)) pass(`Compound Engineering skills directory exists at ${skillsDir}`);
+		else fail(`Compound Engineering skills directory is missing at ${skillsDir}`);
+		if (existsSync(agentsDir)) pass(`Compound Engineering agents directory exists at ${agentsDir}`);
+		else fail(`Compound Engineering agents directory is missing at ${agentsDir}`);
+		const subagentsPkg = PACKAGES.find((pkg) => pkg.id === "subagents");
+		if (subagentsPkg && sources.has(subagentsPkg.source)) pass("pi-subagents installed");
+		else fail("pi-subagents is missing — Compound Engineering requires it");
+		const askUserPkg = PACKAGES.find((pkg) => pkg.id === "pi-ask-user");
+		if (askUserPkg && sources.has(askUserPkg.source)) pass("pi-ask-user installed");
+		else fail("pi-ask-user is missing — Compound Engineering requires it");
+	} else if (compound.mode === "legacy") {
+		warn(`Legacy Compound Engineering marker found at ${compound.legacy.path} — run ${bold("npx @robzolkos/lazypi update")} to migrate to CE 3`);
 	} else {
 		console.log(`  ${dim("·")} Compound Engineering not installed`);
 	}

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -80,99 +80,66 @@
 
   <main class="docs-content">
     <h1>Compound Engineering</h1>
-    <p class="page-desc">Official Compound Engineering from Every, installed through the upstream Pi target converter.</p>
+    <p class="page-desc">Official Compound Engineering 3 from Every, installed through the upstream Pi target.</p>
 
-    <h2>What it does</h2>
+    <h2>What LazyPi installs</h2>
     <p>
-      LazyPi installs the official <code>@every-env/compound-plugin</code> package from Every and runs its Pi target converter. That upstream tool generates Pi-compatible skills, extensions, and agent guidance directly into your Pi config directory.
+      LazyPi uses the upstream <code>@every-env/compound-plugin</code> Bun CLI directly. When you install <code>compound</code>, LazyPi runs the upstream cleanup step first and then installs the official Pi target output into your Pi directory.
     </p>
     <p>
-      In practice, this gives Pi the official Compound Engineering reviewer and workflow skill set — including entry points like <code>/skill:ce-plan</code>, <code>/skill:ce-work</code>, <code>/skill:ce-review</code>, <code>/skill:ce-brainstorm</code>, and <code>/skill:ce-compound</code> — plus the compatibility layer required for subagents and MCP-style access.
-    </p>
-    <p>
-      LazyPi also normalizes the upstream colon-style Compound skill IDs into Pi-compatible hyphenated IDs (for example <code>ce:plan</code> → <code>ce-plan</code>) so current Pi releases do not emit skill-name warnings. That normalization is re-applied on every Compound reinstall or <code>lazypi update</code>.
-    </p>
-    <p>
-      After installing LazyPi, restart or <code>/reload</code> Pi so the generated skills and extensions are loaded into the current session.
+      LazyPi also auto-installs the two runtime dependencies Compound Engineering expects: <a href="/docs/packages/subagents.html">pi-subagents</a> and <code>pi-ask-user</code>. That means <code>npx @robzolkos/lazypi --only compound</code> is enough to get a working CE 3 setup.
     </p>
 
     <h2>Bun requirement</h2>
     <p>
-      The official Every installer is a Bun-based CLI. LazyPi checks for <code>bun</code> before attempting this package. If Bun is missing, LazyPi will warn you and continue installing everything else, but Compound Engineering will be skipped.
+      The official installer is Bun-based. If <code>bun</code> is missing, LazyPi warns and skips Compound Engineering while continuing with the rest of the catalog.
     </p>
 
-    <h2>Why it's included</h2>
+    <h2>Installed layout</h2>
     <p>
-      Compound Engineering remains one of the strongest AI-assisted development methodologies available, and using the upstream package keeps LazyPi aligned with Every's official implementation instead of a third-party fork or repackaging.
+      CE 3 is treated as upstream output, not a LazyPi-managed compatibility fork. After install, the canonical files live under your Pi root:
+    </p>
+    <ul>
+      <li><code>.pi/skills/</code> — Compound Engineering skills</li>
+      <li><code>.pi/agents/</code> — Compound Engineering agents</li>
+      <li><code>.pi/compound-engineering/install-manifest.json</code> — upstream install manifest</li>
+    </ul>
+    <p>
+      LazyPi uses that upstream manifest as the source of truth for detection, updates, health checks, and removal.
+    </p>
+
+    <h2>Updates and migration</h2>
+    <p>
+      <code>npx @robzolkos/lazypi update</code> refreshes Compound Engineering by running upstream cleanup and upstream install again. If LazyPi detects an older pre-CE-3 install, it migrates in place and removes the old LazyPi state file after the CE 3 manifest is present.
     </p>
 
     <h2>Removal</h2>
     <p>
-      LazyPi tracks the files it generates for the official Pi target, so <code>npx @robzolkos/lazypi remove compound</code> removes the generated Compound Engineering files cleanly instead of leaving converted skills behind.
+      <code>npx @robzolkos/lazypi remove compound</code> removes the files listed in the upstream manifest, clears legacy LazyPi state, and deletes the upstream backup directory under <code>.pi/compound-engineering/legacy-backup/</code>.
     </p>
 
     <h2>What shows up in Pi</h2>
     <p>
-      The official Pi target installs a large skill library and supporting tooling rather than a single npm-style Pi package manifest entry. In practice, you get the core Compound Engineering workflows plus a broad bench of reviewer, researcher, planning, testing, and shipping skills that those workflows can call.
+      The install brings in the official Compound Engineering workflow skills plus the supporting specialists those workflows rely on.
     </p>
 
-    <h3>Core Compound Engineering workflow skills</h3>
     <table>
       <thead>
         <tr><th>Skill</th><th>What it does</th></tr>
       </thead>
       <tbody>
-        <tr><td><code>/skill:ce-brainstorm</code></td><td>Explore requirements, constraints, and options before committing to a build</td></tr>
-        <tr><td><code>/skill:ce-ideate</code></td><td>Generate and critique grounded ideas before narrowing to a direction</td></tr>
-        <tr><td><code>/skill:ce-plan</code></td><td>Create a structured implementation plan with repo research and plan review</td></tr>
-        <tr><td><code>/skill:ce-work</code></td><td>Execute implementation work against an approved plan</td></tr>
-        <tr><td><code>/skill:ce-review</code></td><td>Run tiered multi-agent code review before shipping</td></tr>
+        <tr><td><code>/skill:ce-brainstorm</code></td><td>Explore requirements and options before committing to a build</td></tr>
+        <tr><td><code>/skill:ce-plan</code></td><td>Create structured implementation plans</td></tr>
+        <tr><td><code>/skill:ce-work</code></td><td>Execute implementation work against a plan</td></tr>
+        <tr><td><code>/skill:ce-review</code></td><td>Run multi-agent review before shipping</td></tr>
         <tr><td><code>/skill:ce-debug</code></td><td>Investigate bugs and root causes systematically</td></tr>
-        <tr><td><code>/skill:ce-compound</code></td><td>Capture a solved problem as reusable institutional knowledge</td></tr>
-        <tr><td><code>/skill:ce-compound-refresh</code></td><td>Refresh and consolidate stale learning docs under <code>docs/solutions/</code></td></tr>
-        <tr><td><code>/skill:ce-setup</code></td><td>Verify the Compound Engineering environment and troubleshoot setup issues</td></tr>
-      </tbody>
-    </table>
-
-    <h3>Research, planning, and review helpers</h3>
-    <table>
-      <thead>
-        <tr><th>Skill</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><code>/skill:repo-research-analyst</code></td><td>Research repo structure, patterns, conventions, and relevant files</td></tr>
-        <tr><td><code>/skill:learnings-researcher</code></td><td>Search <code>docs/solutions/</code> for prior institutional learnings</td></tr>
-        <tr><td><code>/skill:framework-docs-researcher</code></td><td>Pull official framework or library guidance</td></tr>
-        <tr><td><code>/skill:best-practices-researcher</code></td><td>Gather external best practices and implementation examples</td></tr>
-        <tr><td><code>/skill:spec-flow-analyzer</code></td><td>Check specs and plans for missing flows, edges, and handoffs</td></tr>
-        <tr><td><code>/skill:document-review</code></td><td>Review requirements and plan documents with multiple personas</td></tr>
-        <tr><td><code>/skill:architecture-strategist</code></td><td>Stress-test architectural decisions and system-wide impact</td></tr>
-        <tr><td><code>/skill:security-sentinel</code></td><td>Audit for security risks and missing defenses</td></tr>
-        <tr><td><code>/skill:performance-oracle</code></td><td>Review performance, scalability, and bottlenecks</td></tr>
-        <tr><td><code>/skill:data-integrity-guardian</code></td><td>Review data safety, migration risk, and persistence concerns</td></tr>
-      </tbody>
-    </table>
-
-    <h3>Shipping, communication, and utility skills</h3>
-    <table>
-      <thead>
-        <tr><th>Skill</th><th>What it does</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><code>/skill:ce-pr-description</code></td><td>Draft or refresh a value-first pull request title and body</td></tr>
-        <tr><td><code>/skill:resolve-pr-feedback</code></td><td>Work through PR review comments and thread resolution</td></tr>
-        <tr><td><code>/skill:ce-demo-reel</code></td><td>Create screenshots, GIFs, or recordings for visual proof</td></tr>
-        <tr><td><code>/skill:ce-optimize</code></td><td>Run iterative metric-driven optimization loops</td></tr>
-        <tr><td><code>/skill:proof</code></td><td>Push docs into Proof for human-in-the-loop review and iteration</td></tr>
-        <tr><td><code>/skill:test-browser</code></td><td>Run browser-based testing for affected pages</td></tr>
-        <tr><td><code>/skill:test-xcode</code></td><td>Build and test iOS apps on simulator with Xcode tooling</td></tr>
-        <tr><td><code>/skill:git-commit</code></td><td>Create clear commits with strong messages</td></tr>
-        <tr><td><code>/skill:git-commit-push-pr</code></td><td>Commit, push, and open a PR in one workflow</td></tr>
+        <tr><td><code>/skill:ce-compound</code></td><td>Capture reusable learnings from solved problems</td></tr>
+        <tr><td><code>/skill:ce-compound-refresh</code></td><td>Refresh stale learnings under <code>docs/solutions/</code></td></tr>
       </tbody>
     </table>
 
     <p>
-      Those tables are the most visible entry points, not the full inventory. The official install currently brings in dozens more specialist personas and helpers, including language-specific reviewers, design tools, deployment verification, session history search, Slack research, todo workflows, onboarding generation, and autonomous workflows like <code>/skill:lfg</code>.
+      The exact inventory can evolve with upstream Compound Engineering releases, but LazyPi no longer renames skills, rewrites generated files, or ships a compatibility layer on top of the upstream Pi output.
     </p>
 
     <div class="learn-more">

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">=20"
   },
   "scripts": {
-    "docs:serve": "node scripts/serve-docs.mjs"
+    "docs:serve": "node scripts/serve-docs.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0"

--- a/test/compound-migration.test.mjs
+++ b/test/compound-migration.test.mjs
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = resolve("bin/lazypi.mjs");
+const AUTH_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"TOGETHER_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+];
+
+function requireCommand(name) {
+	const probe = spawnSync("bash", ["-lc", `command -v ${name}`], { encoding: "utf8" });
+	assert.equal(probe.status, 0, `${name} must be available to run the real integration tests`);
+}
+
+function createWorkspace() {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-real-"));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(workspace, { recursive: true });
+	return { root, home, workspace };
+}
+
+function testEnv(home) {
+	const env = { ...process.env, HOME: home };
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	return env;
+}
+
+function runCli(args, { cwd, home, timeout = 600_000 } = {}) {
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		cwd,
+		env: testEnv(home),
+		encoding: "utf8",
+		timeout,
+	});
+	if (result.error) throw result.error;
+	return result;
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readSettings(workspace) {
+	return readJson(join(workspace, ".pi", "settings.json"));
+}
+
+function assertSuccess(result, message = "command should succeed") {
+	assert.equal(result.status, 0, `${message}\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+}
+
+requireCommand("pi");
+requireCommand("bun");
+
+const upstreamVersion = spawnSync("bash", ["-lc", "bunx @every-env/compound-plugin@3.0.0 --help | sed -n '1p'"], { encoding: "utf8", timeout: 180_000 });
+assert.equal(upstreamVersion.status, 0, upstreamVersion.stderr || upstreamVersion.stdout);
+assert.match(upstreamVersion.stdout, /v3\.0\.0/);
+
+test("fresh CE3 install uses real upstream v3 and reports healthy status", { timeout: 600_000 }, () => {
+	const { workspace, home } = createWorkspace();
+	const installResult = runCli(["--yes", "--only", "compound", "-l"], { cwd: workspace, home });
+	assertSuccess(installResult, "fresh compound install failed");
+	assert.match(installResult.stdout, /@every-env\/compound-plugin@3\.0\.0/);
+
+	const manifestPath = join(workspace, ".pi", "compound-engineering", "install-manifest.json");
+	assert.equal(existsSync(manifestPath), true);
+	assert.equal(existsSync(join(workspace, ".pi", "agents")), true);
+	assert.equal(existsSync(join(workspace, ".pi", "skills", "ce-plan", "SKILL.md")), true);
+	assert.equal(existsSync(join(workspace, ".pi", "extensions", "compound-engineering-compat.ts")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "AGENTS.md")), true);
+
+	const manifest = readJson(manifestPath);
+	assert.equal(manifest.pluginName, "compound-engineering");
+	assert.ok(Array.isArray(manifest.skills) && manifest.skills.includes("ce-plan"));
+	assert.ok(Array.isArray(manifest.agents) && manifest.agents.includes("ce-repo-research-analyst.md"));
+
+	const settings = readSettings(workspace);
+	const sources = new Set((settings.packages ?? []).map((entry) => typeof entry === "string" ? entry : entry.source));
+	assert.equal(sources.has("npm:pi-subagents"), true);
+	assert.equal(sources.has("npm:pi-ask-user"), true);
+	assert.equal(sources.has("npm:@every-env/compound-plugin"), false);
+
+	const statusResult = runCli(["status", "-l"], { cwd: workspace, home });
+	assertSuccess(statusResult, "status failed after fresh install");
+	assert.match(statusResult.stdout, /Installed from LazyPi catalog/);
+	assert.match(statusResult.stdout, /compound/);
+	assert.doesNotMatch(statusResult.stdout, /legacy LazyPi state detected/);
+
+	const doctorResult = runCli(["doctor", "-l"], { cwd: workspace, home });
+	assertSuccess(doctorResult, "doctor failed after fresh install");
+	assert.match(doctorResult.stdout, /Compound Engineering manifest found/);
+	assert.match(doctorResult.stdout, /Compound Engineering skills directory exists/);
+	assert.match(doctorResult.stdout, /Compound Engineering agents directory exists/);
+	assert.match(doctorResult.stdout, /pi-subagents installed/);
+	assert.match(doctorResult.stdout, /pi-ask-user installed/);
+	assert.match(doctorResult.stdout, /No credentials detected/);
+	assert.doesNotMatch(doctorResult.stdout, /ce_subagent|compat extension/);
+});
+
+test("legacy LazyPi state migrates to CE3 on real update flow", { timeout: 600_000 }, () => {
+	const { workspace, home } = createWorkspace();
+	mkdirSync(join(workspace, ".pi", ".lazypi"), { recursive: true });
+	mkdirSync(join(workspace, ".pi", "extensions"), { recursive: true });
+	writeFileSync(join(workspace, ".pi", ".lazypi", "compound-engineering.json"), JSON.stringify({ createdFiles: ["extensions/compound-engineering-compat.ts"] }, null, 2) + "\n");
+	writeFileSync(join(workspace, ".pi", "extensions", "compound-engineering-compat.ts"), "legacy compat\n");
+
+	const updateResult = runCli(["update", "-l", "--only", "compound"], { cwd: workspace, home });
+	assertSuccess(updateResult, "migration update failed");
+	assert.match(updateResult.stdout, /Step 1\/2: reconcile LazyPi catalog/);
+	assert.match(updateResult.stdout, /Step 2\/2: pi update/);
+	assert.match(updateResult.stdout, /@every-env\/compound-plugin@3\.0\.0/);
+
+	assert.equal(existsSync(join(workspace, ".pi", "compound-engineering", "install-manifest.json")), true);
+	assert.equal(existsSync(join(workspace, ".pi", ".lazypi", "compound-engineering.json")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "extensions", "compound-engineering-compat.ts")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "compound-engineering", "legacy-backup")), true);
+});
+
+test("remove compound deletes real CE3 artifacts and backup directory", { timeout: 600_000 }, () => {
+	const { workspace, home } = createWorkspace();
+	assertSuccess(runCli(["--yes", "--only", "compound", "-l"], { cwd: workspace, home }), "fresh install for removal test failed");
+	assert.equal(existsSync(join(workspace, ".pi", "compound-engineering", "install-manifest.json")), true);
+
+	const removeResult = runCli(["remove", "compound", "-l"], { cwd: workspace, home });
+	assertSuccess(removeResult, "compound removal failed");
+
+	assert.equal(existsSync(join(workspace, ".pi", "compound-engineering")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "agents")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "skills", "ce-plan")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "AGENTS.md")), false);
+	assert.equal(existsSync(join(workspace, ".pi", ".lazypi", "compound-engineering.json")), false);
+	assert.equal(existsSync(join(workspace, ".pi", "settings.json")), true);
+	assert.equal(existsSync(join(workspace, ".pi", "npm")), true);
+});


### PR DESCRIPTION
## Summary
- pin Compound installs to real upstream `@every-env/compound-plugin@3.0.0`
- migrate LazyPi to CE3 manifest/agents-based install, update, doctor, and removal behavior
- add real end-to-end tests and CI coverage using actual `pi`, `bun`, and upstream Compound v3

## What changed
- auto-install `pi-subagents` and `pi-ask-user` when `compound` is selected
- use upstream CE3 cleanup + install flow and verify via `.pi/compound-engineering/install-manifest.json`
- detect CE installs from the CE3 manifest or legacy LazyPi state during migration
- remove CE artifacts via the real manifest shape plus legacy cleanup handling
- update local `lazypi update` flow to work with real `pi` behavior
- rewrite Compound docs for CE3-only behavior

## Verification
- `npm test`
- real smoke runs for:
  - fresh `--only compound -l` install
  - legacy migration via `lazypi update -l --only compound`
  - `lazypi remove compound`
