### PR TITLE
ci: add manual Windows smoke workflow

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,0 +1,36 @@
+name: windows-smoke
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pi
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run lazypi --yes --except compound
+        run: node bin/lazypi.mjs --yes --except compound
+
+      - name: Assert expected packages for all except compound
+        run: node scripts/assert-installed-packages.mjs --except=compound --check-status
+
+      - name: Doctor passes on Windows
+        run: node bin/lazypi.mjs doctor

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -4,6 +4,7 @@ import { homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { argv, cwd, exit, stdout, stderr } from "node:process";
+import { pathToFileURL } from "node:url";
 import {
 	cancel as clackCancel,
 	confirm as clackConfirm,
@@ -24,7 +25,7 @@ import {
 // --except to narrow it.
 const CATEGORIES = ["core", "ui", "research", "frameworks", "themes"];
 
-const PACKAGES = [
+export const PACKAGES = [
 	{ id: "subagents", category: "core", source: "npm:pi-subagents", description: "Sub-agent execution", hint: "Run isolated sub-agents for parallel work." },
 	{ id: "pi-ask-user", category: "core", source: "npm:pi-ask-user", description: "Ask-user prompts", hint: "Interactive user questions for agent workflows." },
 	{ id: "mcp", category: "core", source: "npm:pi-mcp-adapter", description: "MCP server integration", hint: "Connect Pi to any MCP-compatible tool server." },
@@ -1274,7 +1275,11 @@ async function main() {
 	}
 }
 
-main().then((code) => exit(code ?? 0)).catch((err) => {
-	stderr.write(`${err?.stack || err}\n`);
-	exit(1);
-});
+const entrypoint = argv[1] ? pathToFileURL(resolve(argv[1])).href : null;
+
+if (entrypoint === import.meta.url) {
+	main().then((code) => exit(code ?? 0)).catch((err) => {
+		stderr.write(`${err?.stack || err}\n`);
+		exit(1);
+	});
+}

--- a/scripts/assert-installed-packages.mjs
+++ b/scripts/assert-installed-packages.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { PACKAGES } from "../bin/lazypi.mjs";
+
+const COMPOUND_ID = "compound";
+
+export function packageSourcesFromSettings(settings) {
+	return new Set(
+		(settings?.packages ?? [])
+			.map((entry) => typeof entry === "string" ? entry : entry?.source)
+			.filter(Boolean),
+	);
+}
+
+export function expectedPackageSources({ except = [] } = {}) {
+	const excluded = new Set(except);
+	return PACKAGES
+		.filter((pkg) => !excluded.has(pkg.id))
+		.filter((pkg) => pkg.id !== COMPOUND_ID)
+		.map((pkg) => pkg.source);
+}
+
+function parseArgs(args) {
+	const flags = {
+		except: [],
+		checkStatus: false,
+		settingsPath: join(homedir(), ".pi", "agent", "settings.json"),
+	};
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--check-status") flags.checkStatus = true;
+		else if (arg === "--except") flags.except = parseList(args[++i]);
+		else if (arg.startsWith("--except=")) flags.except = parseList(arg.slice("--except=".length));
+		else if (arg === "--settings") flags.settingsPath = args[++i];
+		else if (arg.startsWith("--settings=")) flags.settingsPath = arg.slice("--settings=".length);
+		else throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	return flags;
+}
+
+function parseList(value) {
+	if (!value) return [];
+	return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+function assertStatusCount(expectedCount) {
+	const statusOutput = execFileSync("node", ["bin/lazypi.mjs", "status"], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const expectedLine = `Installed from LazyPi catalog (${expectedCount}/${PACKAGES.length}):`;
+	assert.match(statusOutput, new RegExp(expectedLine.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+}
+
+export function main() {
+	const flags = parseArgs(process.argv.slice(2));
+	if (!existsSync(flags.settingsPath)) {
+		throw new Error(`settings.json was not created at ${flags.settingsPath}`);
+	}
+
+	const settings = JSON.parse(readFileSync(flags.settingsPath, "utf8"));
+	const actualSources = packageSourcesFromSettings(settings);
+	const expectedSources = expectedPackageSources({ except: flags.except });
+	const expectedSourceSet = new Set(expectedSources);
+	const missing = expectedSources.filter((source) => !actualSources.has(source));
+	const unexpected = [...actualSources].filter((source) => !expectedSourceSet.has(source));
+
+	assert.deepEqual(missing, [], `Missing package sources in settings.json: ${missing.join(", ")}`);
+	assert.deepEqual(unexpected, [], `Unexpected package sources in settings.json: ${unexpected.join(", ")}`);
+
+	if (flags.checkStatus) {
+		const expectedCatalogCount = PACKAGES.filter((pkg) => !flags.except.includes(pkg.id)).length;
+		assertStatusCount(expectedCatalogCount);
+	}
+
+	console.log(`Verified ${expectedSources.length} expected package source(s) in ${flags.settingsPath}.`);
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+
+if (entrypoint === import.meta.url) main();

--- a/test/assert-installed-packages.test.mjs
+++ b/test/assert-installed-packages.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PACKAGES } from "../bin/lazypi.mjs";
+import { expectedPackageSources, packageSourcesFromSettings } from "../scripts/assert-installed-packages.mjs";
+
+test("expectedPackageSources matches full catalog except compound's unmanaged source", () => {
+	const expected = expectedPackageSources();
+
+	assert.equal(expected.includes("npm:@every-env/compound-plugin"), false);
+	assert.equal(expected.length, PACKAGES.length - 1);
+});
+
+test("expectedPackageSources supports excluded package ids", () => {
+	const expected = expectedPackageSources({ except: ["compound", "pi-ask-user"] });
+
+	assert.equal(expected.includes("npm:@every-env/compound-plugin"), false);
+	assert.equal(expected.includes("npm:pi-ask-user"), false);
+	assert.equal(expected.length, PACKAGES.length - 2);
+});
+
+test("packageSourcesFromSettings reads string and object package entries", () => {
+	const sources = packageSourcesFromSettings({
+		packages: [
+			"npm:pi-subagents",
+			{ source: "npm:pi-ask-user" },
+			{ source: "npm:pi-mcp-adapter", extra: true },
+			{ nope: true },
+		],
+	});
+
+	assert.deepEqual([...sources].sort(), ["npm:pi-ask-user", "npm:pi-mcp-adapter", "npm:pi-subagents"]);
+});


### PR DESCRIPTION
## Summary
- add a manual `windows-smoke` workflow on GitHub Actions
- add a shared package expectation helper driven by the LazyPi catalog
- add tests for the shared expectation helper

## Why
This gets the workflow onto `master` so it can be manually dispatched against feature branches/PRs before those branches are merged.

## Validation
- npm test