### PR TITLE
fix(cli): restore npx lazypi entrypoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run test suite
         run: npm test
 
+      - name: Smoke-test packed CLI artifact
+        run: node scripts/packed-cli-smoke.mjs
+
       - name: Run lazypi --yes
         run: node bin/lazypi.mjs --yes
 

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run full test suite
         run: npm test
 
+      - name: Smoke-test packed CLI artifact
+        run: node scripts/packed-cli-smoke.mjs
+
       - name: Run lazypi --yes
         run: node bin/lazypi.mjs --yes
 
@@ -57,6 +60,9 @@ jobs:
         run: npm test
         env:
           LAZYPI_SKIP_COMPOUND_INTEGRATION: "1"
+
+      - name: Smoke-test packed CLI artifact
+        run: node scripts/packed-cli-smoke.mjs
 
       - name: Run lazypi --yes --except compound
         run: node bin/lazypi.mjs --yes --except compound

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -1289,7 +1289,16 @@ async function main() {
 	}
 }
 
-const entrypoint = argv[1] ? pathToFileURL(resolve(argv[1])).href : null;
+export function resolveEntrypointUrl(scriptPath) {
+	if (!scriptPath) return null;
+	try {
+		return pathToFileURL(realpathSync(scriptPath)).href;
+	} catch {
+		return pathToFileURL(resolve(scriptPath)).href;
+	}
+}
+
+const entrypoint = resolveEntrypointUrl(argv[1]);
 
 if (entrypoint === import.meta.url) {
 	main().then((code) => exit(code ?? 0)).catch((err) => {

--- a/scripts/packed-cli-smoke.mjs
+++ b/scripts/packed-cli-smoke.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function npmExecutable(platformName = process.platform) {
+	return platformName === "win32" ? "npm.cmd" : "npm";
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, { encoding: "utf8", ...options });
+	if (result.error) throw result.error;
+	return result;
+}
+
+function resultSummary(result) {
+	return `exit=${result.status ?? "null"}\nSTDOUT:\n${result.stdout ?? ""}\nSTDERR:\n${result.stderr ?? ""}`;
+}
+
+export function runPackedCliSmoke({ cwd = process.cwd() } = {}) {
+	const npm = npmExecutable();
+	const pack = run(npm, ["pack", "--silent"], { cwd });
+	assert.equal(pack.status, 0, `npm pack failed\n${resultSummary(pack)}`);
+
+	const tarballName = pack.stdout.trim().split(/\r?\n/).filter(Boolean).at(-1);
+	assert.ok(tarballName, `npm pack did not print a tarball name\n${resultSummary(pack)}`);
+
+	const tarballPath = resolve(cwd, tarballName);
+	assert.equal(existsSync(tarballPath), true, `packed tarball was not created at ${tarballPath}`);
+
+	try {
+		const smoke = run(npm, ["exec", "--yes", `--package=${tarballPath}`, "--call", "lazypi --help"], { cwd });
+		assert.equal(smoke.status, 0, `packed CLI smoke failed\n${resultSummary(smoke)}`);
+		assert.match(smoke.stdout, /lazypi — opinionated installer for Pi extensions/);
+		assert.match(smoke.stdout, /Usage:/);
+		return { pack, smoke, tarballPath };
+	} finally {
+		rmSync(tarballPath, { force: true });
+	}
+}
+
+const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+
+if (entrypoint === import.meta.url) {
+	const { smoke } = runPackedCliSmoke();
+	process.stdout.write(smoke.stdout);
+}

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const PACKED_CLI_SMOKE_COMMAND = "node scripts/packed-cli-smoke.mjs";
+
+function readWorkflow(path) {
+	return readFileSync(path, "utf8");
+}
+
+test("packed CLI smoke script exists", () => {
+	assert.equal(existsSync("scripts/packed-cli-smoke.mjs"), true);
+});
+
+test("linux CI workflow smoke-tests the packed CLI artifact", () => {
+	const workflow = readWorkflow(".github/workflows/test.yml");
+	assert.equal(workflow.includes(PACKED_CLI_SMOKE_COMMAND), true);
+});
+
+test("windows CI workflow smoke-tests the packed CLI artifact in both jobs", () => {
+	const workflow = readWorkflow(".github/workflows/windows-smoke.yml");
+	const hits = workflow.split(PACKED_CLI_SMOKE_COMMAND).length - 1;
+	assert.equal(hits, 2);
+});

--- a/test/spawn-command.test.mjs
+++ b/test/spawn-command.test.mjs
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { buildSpawnOptions } from "../bin/lazypi.mjs";
+import { buildSpawnOptions, resolveEntrypointUrl } from "../bin/lazypi.mjs";
 
 test("buildSpawnOptions enables shell on Windows by default", () => {
 	assert.deepEqual(buildSpawnOptions({ stdio: "inherit" }, "win32"), {
@@ -21,4 +25,20 @@ test("buildSpawnOptions leaves Unix options unchanged", () => {
 	assert.deepEqual(buildSpawnOptions({ stdio: "inherit" }, "linux"), {
 		stdio: "inherit",
 	});
+});
+
+test("resolveEntrypointUrl resolves symlinked bin paths to the module url", () => {
+	const tmp = mkdtempSync(join(tmpdir(), "lazypi-entrypoint-"));
+	const targetPath = fileURLToPath(new URL("../bin/lazypi.mjs", import.meta.url));
+	const symlinkPath = join(tmp, "lazypi");
+	symlinkSync(targetPath, symlinkPath);
+
+	assert.equal(resolveEntrypointUrl(targetPath), new URL("../bin/lazypi.mjs", import.meta.url).href);
+	assert.equal(resolveEntrypointUrl(symlinkPath), new URL("../bin/lazypi.mjs", import.meta.url).href);
+});
+
+test("resolveEntrypointUrl falls back to a resolved path when realpath lookup fails", () => {
+	const tmp = mkdtempSync(join(tmpdir(), "lazypi-entrypoint-fallback-"));
+	const missingPath = join(tmp, "missing.mjs");
+	assert.equal(resolveEntrypointUrl(missingPath), pathToFileURL(missingPath).href);
 });


### PR DESCRIPTION
## Summary

`npx @robzolkos/lazypi` was exiting cleanly with no output because the CLI entrypoint guard compared `argv[1]` to `import.meta.url` without resolving npm's `.bin` symlink. This switches the comparison to a realpath-aware helper so the published CLI runs again when invoked through `npx` and `npm exec`.

This also closes the test gap that let the regression ship. The suite now covers the symlinked entrypoint directly, adds a packed-artifact smoke test that runs `npm pack` plus `npm exec ... lazypi --help`, and requires both CI workflows to run that smoke path so future releases exercise the same install path users hit.

## Testing

- `npm test`
- `node scripts/packed-cli-smoke.mjs`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
