### PR TITLE
Add Claude Code CLI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LazyPi will:
 1. Install `pi` for you if it isn't installed yet.
 2. Ask if you want to install all the packages or choose which to install.
 
-That setup includes agent tooling, memory, planning, interactive shell overlays for long-running CLIs, usage tracking, and themes.
+That setup includes agent tooling, memory, planning, a Claude Code CLI provider, interactive shell overlays for long-running CLIs, usage tracking, and themes.
 
 That's it.  Once done - run `pi` and experience a feature rich coding agent experience.
 

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -43,6 +43,7 @@ export const PACKAGES = [
 	{ id: "simplify", category: "core", source: "npm:pi-simplify", description: "Code simplify review", hint: "Reviews recently changed code for clarity, consistency, and maintainability." },
 	{ id: "add-dir", category: "core", source: "npm:pi-add-dir", description: "Add external directories", hint: "Load configs and skills from additional project directories in the same Pi session." },
 	{ id: "prompt-templates", category: "core", source: "npm:pi-prompt-template-model", description: "Prompt template model switching", hint: "Add model, skill, and thinking frontmatter so prompt templates switch modes automatically." },
+	{ id: "claude-cli", category: "core", source: "npm:pi-claude-cli", description: "Claude Code CLI provider", hint: "Use Claude Code CLI auth as a Pi model provider." },
 	{ id: "plannotator", category: "ui", source: "npm:@plannotator/pi-extension", description: "Planning and annotation workflow", hint: "Plan + annotate large changes interactively." },
 	{ id: "powerbar", category: "ui", source: "npm:@juanibiapina/pi-powerbar", description: "Powerbar UI", hint: "Status line for Pi with live context." },
 	{ id: "extension-settings", category: "ui", source: "npm:@juanibiapina/pi-extension-settings", description: "Settings support for powerbar", hint: "Required by powerbar for its settings panel." },
@@ -238,7 +239,7 @@ ${bold("Default behaviour:")}
   - With --yes, --only, or --except the picker is skipped.
 
 ${bold("Categories:")}
-  core         foundations: sub-agents, MCP, web access, memory, prompt templates, …
+  core         foundations: sub-agents, MCP, web access, memory, model providers, …
   ui           powerbar, interactive shell overlays, usage dashboard, …
   research     autonomous research / experiment loops
   frameworks   structured engineering workflows

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -66,6 +66,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -147,7 +148,7 @@ pi</code></pre>
 
     <h2>4. Know what changed</h2>
     <p>
-      LazyPi keeps Pi's minimal core intact and installs a curated set of community packages on top. After installation, Pi can still do everything it could before — you just now also have themes, planning mode, MCP support, memory, sub-agents, usage tracking, and workflow helpers available.
+      LazyPi keeps Pi's minimal core intact and installs a curated set of community packages on top. After installation, Pi can still do everything it could before — you just now also have themes, planning mode, MCP support, memory, sub-agents, Claude Code CLI provider support, usage tracking, and workflow helpers available.
     </p>
     <p>
       In other words: LazyPi is a curated starting point, not a fork and not a separate product.

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -66,6 +66,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -96,7 +97,7 @@
     </p>
 
     <h2>What it installs</h2>
-    <p>LazyPi installs 25 hand-picked packages across five categories:</p>
+    <p>LazyPi installs 26 hand-picked packages across five categories:</p>
 
     <table>
       <thead>
@@ -129,6 +130,10 @@
         <tr>
           <td>Memory</td>
           <td>Persistent, Git-backed Markdown memory that survives session resets</td>
+        </tr>
+        <tr>
+          <td>Model providers</td>
+          <td>Claude Code CLI backend support for using Claude Pro/Max auth inside Pi</td>
         </tr>
         <tr>
           <td>Cost tracking</td>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -66,6 +66,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -107,7 +108,7 @@
 
     <h2>Install all vs. interactive picker</h2>
     <p>
-      Choosing <strong>Install all (recommended)</strong> installs all 25 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
+      Choosing <strong>Install all (recommended)</strong> installs all 26 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
     </p>
     <p>
       The interactive picker lets you browse the catalog and select only what you want. Use arrow keys to navigate, space to toggle, and enter to confirm.

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link active">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/claude-cli.html
+++ b/docs/docs/packages/claude-cli.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>MCP Adapter — LazyPi Docs</title>
+  <title>Claude Code CLI — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -55,16 +55,15 @@
     <nav class="sidebar-nav">
       <a href="/docs/packages/" class="sidebar-link">All packages</a>
       <a href="/docs/packages/subagents.html" class="sidebar-link">Sub-agents</a>
-      <a href="/docs/packages/mcp-adapter.html" class="sidebar-link active">MCP Adapter</a>
+      <a href="/docs/packages/mcp-adapter.html" class="sidebar-link">MCP Adapter</a>
       <a href="/docs/packages/web-access.html" class="sidebar-link">Web Access</a>
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
       <a href="/docs/packages/diff-review.html" class="sidebar-link">Diff Review</a>
       <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
-      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link active">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -80,54 +79,61 @@
   </aside>
 
   <main class="docs-content">
-    <h1>MCP Adapter</h1>
-    <p class="page-desc">Token-efficient MCP proxy with lazy server startup and on-demand tool discovery.</p>
+    <h1>Claude Code CLI</h1>
+    <p class="page-desc">Use the Claude Code CLI as a Pi model provider, backed by your Claude Pro or Max subscription.</p>
 
     <h2>What it does</h2>
     <p>
-      MCP (Model Context Protocol) servers expose tools to AI agents — databases, file systems, APIs, search engines, and more. The problem is that each connected server adds its full tool list to the context window on every turn, burning tokens even when those tools aren't used.
+      Pi-claude-cli registers a custom Pi provider named <code>pi-claude-cli</code>. When you select one of its Claude models in <code>/model</code>, Pi sends model requests through the local <code>claude</code> command instead of a direct Anthropic API key.
     </p>
     <p>
-      Pi-MCP-Adapter solves this by proxying all connected MCP servers through a single <code>mcp</code> tool that costs around 200 tokens. Tools are discovered on demand: the agent asks "what tools does server X have?" and the adapter fetches them only when needed. Servers are started lazily — they spin up on first use, not at session start.
-    </p>
-    <p>
-      For tools you use frequently, a direct-tool mode bypasses the proxy and exposes them as first-class tools — no extra round-trip. You can toggle this per-tool from the <code>/mcp</code> panel.
+      Each turn runs Claude Code CLI in stream-json mode, streams text and thinking back into Pi, and lets Pi execute tool calls natively. The extension also resumes Claude Code CLI sessions between turns and exposes custom Pi tools to Claude through a schema-only MCP bridge.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      MCP is how Pi connects to the outside world. Without an adapter, each connected server adds hundreds or thousands of tokens of tool definitions on every single turn. For a session with multiple MCP servers, this makes long conversations significantly more expensive. The adapter is the correct architectural solution: pay for tools when you use them, not by default.
+      Many Pi users already have Claude Code authenticated through a Claude Pro or Max subscription. Claude Code CLI makes that subscription usable as a Pi backend without setting up separate Anthropic API billing, while still keeping Pi's native tools, UI, and package ecosystem in charge.
+    </p>
+    <p>
+      It fits LazyPi as a practical bridge: install the package, make sure Claude Code CLI is available and authenticated, then pick the Claude model provider from Pi's normal model selector.
     </p>
 
-    <h2>Commands</h2>
+    <h2>Usage notes</h2>
     <table>
       <thead>
-        <tr><th>Command</th><th>What it does</th></tr>
+        <tr><th>Step</th><th>What to do</th></tr>
       </thead>
       <tbody>
         <tr>
-          <td><code>/mcp</code></td>
-          <td>Open the interactive panel — view servers, connection status, tools, toggle direct/proxy mode, reconnect, handle OAuth</td>
+          <td>Install Claude Code CLI</td>
+          <td><code>npm install -g @anthropic-ai/claude-code</code></td>
         </tr>
         <tr>
-          <td><code>/mcp reconnect &lt;server&gt;</code></td>
-          <td>Force reconnect a specific MCP server</td>
+          <td>Authenticate Claude</td>
+          <td><code>claude auth login</code></td>
+        </tr>
+        <tr>
+          <td>Select in Pi</td>
+          <td>Open <code>/model</code> and choose a Claude model under the <code>pi-claude-cli</code> provider</td>
         </tr>
       </tbody>
     </table>
+    <p>
+      The provider depends on <code>claude</code> being on your <code>PATH</code>. If Claude Code CLI is missing or not authenticated, the extension logs setup instructions and Pi can continue using your other configured providers.
+    </p>
 
     <div class="learn-more">
-      <a href="https://github.com/nicobailon/pi-mcp-adapter" target="_blank" rel="noopener">→ GitHub — nicobailon/pi-mcp-adapter</a>
+      <a href="https://github.com/rchern/pi-claude-cli" target="_blank" rel="noopener">→ GitHub — rchern/pi-claude-cli</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/subagents.html" class="prev-next-link">
+      <a href="/docs/packages/prompt-templates.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Sub-agents
+        ← Prompt Templates
       </a>
-      <a href="/docs/packages/web-access.html" class="prev-next-link next">
+      <a href="/docs/packages/plannotator.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Web Access →
+        Plannotator →
       </a>
     </nav>
 

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/diff-review.html
+++ b/docs/docs/packages/diff-review.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/extension-settings.html
+++ b/docs/docs/packages/extension-settings.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link active">Extension Settings</a>

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Packages — LazyPi Docs</title>
-  <meta name="description" content="The 20 non-theme packages included in LazyPi, with themes documented separately.">
+  <meta name="description" content="The 21 non-theme packages included in LazyPi, with themes documented separately.">
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -65,6 +65,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -81,7 +82,7 @@
 
   <main class="docs-content">
     <h1>Packages</h1>
-    <p class="page-desc">20 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
+    <p class="page-desc">21 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">
@@ -128,6 +129,11 @@
         <span class="pkg-tag core">core</span>
         <div class="pkg-name">Prompt Templates</div>
         <div class="pkg-desc">Add model, skill, and thinking frontmatter so prompt templates switch modes automatically</div>
+      </a>
+      <a class="pkg-card" href="/docs/packages/claude-cli.html">
+        <span class="pkg-tag core">core</span>
+        <div class="pkg-name">Claude Code CLI</div>
+        <div class="pkg-desc">Use Claude Code CLI auth as a Pi model provider for Claude Pro and Max subscriptions</div>
       </a>
       <a class="pkg-card" href="/docs/packages/plannotator.html">
         <span class="pkg-tag ui">ui</span>

--- a/docs/docs/packages/interactive-shell.html
+++ b/docs/docs/packages/interactive-shell.html
@@ -49,6 +49,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/memory.html
+++ b/docs/docs/packages/memory.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/plan.html
+++ b/docs/docs/packages/plan.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/plannotator.html
+++ b/docs/docs/packages/plannotator.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link active">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -129,9 +130,9 @@
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/prompt-templates.html" class="prev-next-link">
+      <a href="/docs/packages/claude-cli.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Prompt Templates
+        ← Claude Code CLI
       </a>
       <a href="/docs/packages/powerbar.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link active">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link active">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
@@ -122,9 +123,9 @@ Start a Python REPL session and help me debug: $@</code></pre>
         <span class="prev-next-label">Previous</span>
         ← Add Directory
       </a>
-      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
+      <a href="/docs/packages/claude-cli.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Powerbar →
+        Claude Code CLI →
       </a>
     </nav>
 

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/raw-paste.html
+++ b/docs/docs/packages/raw-paste.html
@@ -63,6 +63,7 @@
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/simplify.html
+++ b/docs/docs/packages/simplify.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -66,6 +66,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -66,6 +66,7 @@
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
 
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
+      <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -320,7 +320,7 @@
   <div class="faq-item">
     <div class="faq-q">What does LazyPi install?</div>
     <div class="faq-a">
-      LazyPi installs a curated set of community-built packages including themes, MCP server support, sub-agents, persistent memory, cost and usage tracking, a todo tracker, autoresearch, diff review, planning mode, and structured engineering workflows like Compound Engineering. You can see the full list on the <a href="/#catalog">catalog</a> section.
+      LazyPi installs a curated set of community-built packages including themes, MCP server support, sub-agents, persistent memory, Claude Code CLI provider support, cost and usage tracking, a todo tracker, autoresearch, diff review, planning mode, and structured engineering workflows like Compound Engineering. You can see the full list on the <a href="/#catalog">catalog</a> section.
     </div>
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>LazyPi — One command. Full Pi setup.</title>
-  <meta name="description" content="Run one command and get a complete, curated Pi coding agent setup — 60+ skills, 76 themes, MCP servers, sub-agents, memory, and more.">
+  <meta name="description" content="Run one command and get a complete, curated Pi coding agent setup — 60+ skills, 76 themes, MCP servers, sub-agents, Claude Code CLI provider, memory, and more.">
 
   <!-- Open Graph -->
   <meta property="og:title" content="LazyPi — The fastest way to fall in love with Pi.">
-  <meta property="og:description" content="One command installs 60+ community skills, 76 themes, MCP servers, memory, and more. See what Pi is capable of before you spend an hour configuring it.">
+  <meta property="og:description" content="One command installs 60+ community skills, 76 themes, MCP servers, Claude Code CLI provider, memory, and more. See what Pi is capable of before you spend an hour configuring it.">
   <meta property="og:url" content="https://lazypi.org">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://lazypi.org/og.png">
@@ -17,7 +17,7 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="LazyPi — The fastest way to fall in love with Pi.">
-  <meta name="twitter:description" content="One command installs 60+ community skills, 76 themes, MCP servers, memory, and more.">
+  <meta name="twitter:description" content="One command installs 60+ community skills, 76 themes, MCP servers, Claude Code CLI provider, memory, and more.">
   <meta name="twitter:image" content="https://lazypi.org/og.png">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -659,7 +659,7 @@
   <p class="hero-tagline">One command. Everything configured. Nothing to research.</p>
   <p class="hero-sub">
     One command installs 60+ community skills, 76 themes, MCP support, sub-agent
-    support, memory, and more. You're left with a curated starting point that gets you an exciting, useful experience immediately, without the research and configuration tax.
+    support, Claude Code CLI provider support, memory, and more. You're left with a curated starting point that gets you an exciting, useful experience immediately, without the research and configuration tax.
   </p>
 
   <div class="terminal">
@@ -750,6 +750,11 @@
         </tr>
         <tr>
           <td>Persistent memory</td>
+          <td><span class="cross">✕</span></td>
+          <td><span class="check">✓</span></td>
+        </tr>
+        <tr>
+          <td>Claude Code CLI provider</td>
           <td><span class="cross">✕</span></td>
           <td><span class="check">✓</span></td>
         </tr>
@@ -851,6 +856,12 @@
         <div class="catalog-name">pi-prompt-template-model</div>
         <div class="catalog-desc">Prompt templates with model, skill, and thinking frontmatter</div>
         <div class="catalog-author">by nicobailon</div>
+      </a>
+      <a class="catalog-card" href="https://github.com/rchern/pi-claude-cli" target="_blank" rel="noopener">
+        <span class="catalog-tag core">core</span>
+        <div class="catalog-name">pi-claude-cli</div>
+        <div class="catalog-desc">Use Claude Code CLI auth as a Pi model provider</div>
+        <div class="catalog-author">by rchern</div>
       </a>
       <a class="catalog-card" href="https://github.com/backnotprop/plannotator/tree/main/apps/pi-extension" target="_blank" rel="noopener">
         <span class="catalog-tag ui">ui</span>


### PR DESCRIPTION
## Summary
- add pi-claude-cli to the LazyPi core catalog as the Claude Code CLI provider
- add a dedicated package docs page and update package counts/navigation
- update the public site and overview copy to reference Claude Code CLI provider support

## Tests
- npm test