### PR TITLE
feat: add pi-slopchop package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Project overview
+
+LazyPi is an opinionated installer for the Pi coding agent. It provides a curated catalog of Pi extensions, themes, skills, and workflow tools so users can run one command and get a complete Pi setup.
+
+The CLI is published to npm as `@robzolkos/lazypi`. The main executable is `bin/lazypi.mjs`, with package metadata and install behavior centered around the `PACKAGES` catalog in that file. Public documentation is hand-authored static HTML under `docs/`.
+
+
+## Git guidance
+
+Use Conventional Commits for commit messages, for example `feat: add package to catalog`, `fix: handle package install failure`, or `docs: update package documentation`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LazyPi will:
 1. Install `pi` for you if it isn't installed yet.
 2. Ask if you want to install all the packages or choose which to install.
 
-That setup includes agent tooling, memory, planning, a Claude Code CLI provider, interactive shell overlays for long-running CLIs, usage tracking, and themes.
+That setup includes agent tooling, memory, planning, terminal-native diff review, a Claude Code CLI provider, interactive shell overlays for long-running CLIs, usage tracking, and themes.
 
 That's it.  Once done - run `pi` and experience a feature rich coding agent experience.
 

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -44,6 +44,7 @@ export const PACKAGES = [
 	{ id: "prompt-templates", category: "core", source: "npm:pi-prompt-template-model", description: "Prompt template model switching", hint: "Add model, skill, and thinking frontmatter so prompt templates switch modes automatically." },
 	{ id: "claude-cli", category: "core", source: "npm:pi-claude-cli", description: "Claude Code CLI provider", hint: "Use Claude Code CLI auth as a Pi model provider." },
 	{ id: "plannotator", category: "ui", source: "npm:@plannotator/pi-extension", description: "Planning and annotation workflow", hint: "Plan + annotate large changes interactively." },
+	{ id: "slopchop", category: "ui", source: "npm:pi-slopchop", description: "Diff review and annotation", hint: "Review diffs inside Pi and turn FIX/DISCUSS annotations into the next prompt." },
 	{ id: "powerbar", category: "ui", source: "npm:@juanibiapina/pi-powerbar", description: "Powerbar UI", hint: "Status line for Pi with live context." },
 	{ id: "extension-settings", category: "ui", source: "npm:@juanibiapina/pi-extension-settings", description: "Settings support for powerbar", hint: "Required by powerbar for its settings panel." },
 	{ id: "usage", category: "ui", source: "npm:@tmustier/pi-usage-extension", description: "Usage and cost dashboard", hint: "Track token usage and API cost in-session." },

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -67,6 +67,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -67,6 +67,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -96,7 +97,7 @@
     </p>
 
     <h2>What it installs</h2>
-    <p>LazyPi installs 25 hand-picked packages across five categories:</p>
+    <p>LazyPi installs 26 hand-picked packages across five categories:</p>
 
     <table>
       <thead>
@@ -137,6 +138,10 @@
         <tr>
           <td>Cost tracking</td>
           <td>Per-session and historical token/cost dashboards</td>
+        </tr>
+        <tr>
+          <td>Diff review</td>
+          <td>Terminal-native review with precise FIX and DISCUSS annotations</td>
         </tr>
       </tbody>
     </table>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -67,6 +67,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -107,7 +108,7 @@
 
     <h2>Install all vs. interactive picker</h2>
     <p>
-      Choosing <strong>Install all (recommended)</strong> installs all 25 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
+      Choosing <strong>Install all (recommended)</strong> installs all 26 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
     </p>
     <p>
       The interactive picker lets you browse the catalog and select only what you want. Use arrow keys to navigate, space to toggle, and enter to confirm.

--- a/docs/docs/packages/add-dir.html
+++ b/docs/docs/packages/add-dir.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/autoresearch.html
+++ b/docs/docs/packages/autoresearch.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/btw.html
+++ b/docs/docs/packages/btw.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/claude-cli.html
+++ b/docs/docs/packages/claude-cli.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link active">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/compound-engineering.html
+++ b/docs/docs/packages/compound-engineering.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/extension-settings.html
+++ b/docs/docs/packages/extension-settings.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link active">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Packages — LazyPi Docs</title>
-  <meta name="description" content="The 20 non-theme packages included in LazyPi, with themes documented separately.">
+  <meta name="description" content="The 21 non-theme packages included in LazyPi, with themes documented separately.">
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -66,6 +66,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -81,7 +82,7 @@
 
   <main class="docs-content">
     <h1>Packages</h1>
-    <p class="page-desc">20 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
+    <p class="page-desc">21 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">
@@ -133,6 +134,11 @@
         <span class="pkg-tag ui">ui</span>
         <div class="pkg-name">Plannotator</div>
         <div class="pkg-desc">Visual plan review and markdown annotation through a local browser UI</div>
+      </a>
+      <a class="pkg-card" href="/docs/packages/slopchop.html">
+        <span class="pkg-tag ui">ui</span>
+        <div class="pkg-name">Slopchop</div>
+        <div class="pkg-desc">Terminal-native diff review with FIX and DISCUSS annotations</div>
       </a>
       <a class="pkg-card" href="/docs/packages/powerbar.html">
         <span class="pkg-tag ui">ui</span>

--- a/docs/docs/packages/interactive-shell.html
+++ b/docs/docs/packages/interactive-shell.html
@@ -50,6 +50,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/mcp-adapter.html
+++ b/docs/docs/packages/mcp-adapter.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/memory.html
+++ b/docs/docs/packages/memory.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/plannotator.html
+++ b/docs/docs/packages/plannotator.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link active">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -133,9 +134,9 @@
         <span class="prev-next-label">Previous</span>
         ← Claude Code CLI
       </a>
-      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
+      <a href="/docs/packages/slopchop.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Powerbar →
+        Slopchop →
       </a>
     </nav>
 

--- a/docs/docs/packages/powerbar.html
+++ b/docs/docs/packages/powerbar.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link active">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -102,9 +103,9 @@
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/prompt-templates.html" class="prev-next-link">
+      <a href="/docs/packages/slopchop.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Prompt Templates
+        ← Slopchop
       </a>
       <a href="/docs/packages/usage.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>

--- a/docs/docs/packages/prompt-templates.html
+++ b/docs/docs/packages/prompt-templates.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link active">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/ralph-wiggum.html
+++ b/docs/docs/packages/ralph-wiggum.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/raw-paste.html
+++ b/docs/docs/packages/raw-paste.html
@@ -64,6 +64,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/simplify.html
+++ b/docs/docs/packages/simplify.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/slopchop.html
+++ b/docs/docs/packages/slopchop.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-  <title>Plan — LazyPi Docs</title>
+  <title>Slopchop — LazyPi Docs</title>
   <link rel="stylesheet" href="/docs.css">
 </head>
 <body>
@@ -58,14 +58,13 @@
       <a href="/docs/packages/mcp-adapter.html" class="sidebar-link">MCP Adapter</a>
       <a href="/docs/packages/web-access.html" class="sidebar-link">Web Access</a>
       <a href="/docs/packages/memory.html" class="sidebar-link">Memory</a>
-      <a href="/docs/packages/plan.html" class="sidebar-link active">Plan</a>
+      <a href="/docs/packages/plan.html" class="sidebar-link">Plan</a>
       <a href="/docs/packages/simplify.html" class="sidebar-link">Simplify</a>
       <a href="/docs/packages/add-dir.html" class="sidebar-link">Add Directory</a>
-
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
-      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link active">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>
@@ -80,67 +79,67 @@
   </aside>
 
   <main class="docs-content">
-    <h1>Plan</h1>
-    <p class="page-desc">Read-only planning mode that blocks code changes until you explicitly approve the plan.</p>
+    <h1>Slopchop</h1>
+    <p class="page-desc">Terminal-native diff review and annotation for turning precise feedback into the next Pi prompt.</p>
 
     <h2>What it does</h2>
     <p>
-      Pi-plan enforces a two-phase workflow: investigate first, then execute. When plan mode is active, mutating tools and bash write commands are blocked. Pi can read files, search code, and reason about the problem — but it cannot make changes until you approve.
+      Slopchop adds a <code>/slopchop</code> review surface inside Pi. After an agent turn, you can walk the current git diff, the last commit, or all files without leaving the terminal, then attach line-level, file-level, or whole-change annotations.
     </p>
     <p>
-      Once you review the plan and give approval, Pi exits plan mode and proceeds with implementation. The <code>/todos</code> command tracks plan progress as a checklist, showing which steps are complete and which are pending.
+      Each annotation is marked as either <strong>FIX</strong> for changes the agent should make or <strong>DISCUSS</strong> for explanations, rationale, and follow-up questions. When you submit the review, Slopchop inserts a structured prompt into Pi's editor instead of auto-sending it, so you can read and tweak the feedback first.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Agents that jump straight to implementation on complex tasks tend to make confident, hard-to-reverse mistakes. Plan mode creates a natural review checkpoint that matches how senior engineers actually work: understand the problem fully before writing a line of code. It costs nothing when you don't need it and saves significant time when you do.
+      LazyPi includes tools that keep humans in control of agent work. Slopchop makes that control fast and terminal-native: inspect changed lines, ask about deleted code, separate discussion from requested fixes, and hand the agent exact next-turn feedback without switching to another review tool.
     </p>
 
-    <h2>Commands</h2>
+    <h2>Commands and shortcuts</h2>
     <table>
       <thead>
         <tr><th>Command</th><th>What it does</th></tr>
       </thead>
       <tbody>
         <tr>
-          <td><code>/plan</code></td>
-          <td>Toggle plan mode on/off</td>
+          <td><code>/slopchop</code></td>
+          <td>Open the review UI for git diff, last commit, or all files</td>
         </tr>
         <tr>
-          <td><code>/plan on</code></td>
-          <td>Enable plan mode</td>
+          <td><code>ctrl+alt+s</code></td>
+          <td>Global shortcut for opening Slopchop</td>
         </tr>
         <tr>
-          <td><code>/plan off</code></td>
-          <td>Disable plan mode</td>
+          <td><code>f</code></td>
+          <td>Add a line annotation with FIX preselected</td>
         </tr>
         <tr>
-          <td><code>/plan status</code></td>
-          <td>Show whether plan mode is currently active</td>
+          <td><code>d</code> or <code>c</code></td>
+          <td>Add a line annotation with DISCUSS preselected</td>
         </tr>
         <tr>
-          <td><code>/plan &lt;task&gt;</code></td>
-          <td>Enable plan mode and start planning the specified task immediately</td>
-        </tr>
-        <tr>
-          <td><code>/todos</code></td>
-          <td>Show tracked plan progress as a checklist of completed and pending steps</td>
+          <td><code>s</code></td>
+          <td>Insert the generated review prompt into Pi's editor</td>
         </tr>
       </tbody>
     </table>
 
+    <p>
+      Slopchop also supports slash shortcut mode for fast templated comments and an optional <code>~/.pi/agent/extensions/slopchop.json</code> file for custom review shortcuts.
+    </p>
+
     <div class="learn-more">
-      <a href="https://github.com/devkade/pi-plan" target="_blank" rel="noopener">→ GitHub — devkade/pi-plan</a>
+      <a href="https://github.com/robzolkos/pi-slopchop" target="_blank" rel="noopener">→ GitHub — robzolkos/pi-slopchop</a>
     </div>
 
     <nav class="prev-next">
-      <a href="/docs/packages/memory.html" class="prev-next-link">
+      <a href="/docs/packages/plannotator.html" class="prev-next-link">
         <span class="prev-next-label">Previous</span>
-        ← Memory
+        ← Plannotator
       </a>
-      <a href="/docs/packages/simplify.html" class="prev-next-link next">
+      <a href="/docs/packages/powerbar.html" class="prev-next-link next">
         <span class="prev-next-label">Next</span>
-        Simplify →
+        Powerbar →
       </a>
     </nav>
 

--- a/docs/docs/packages/subagents.html
+++ b/docs/docs/packages/subagents.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/todo.html
+++ b/docs/docs/packages/todo.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/packages/usage.html
+++ b/docs/docs/packages/usage.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link active">Usage Tracker</a>

--- a/docs/docs/packages/web-access.html
+++ b/docs/docs/packages/web-access.html
@@ -65,6 +65,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/removing.html
+++ b/docs/docs/removing.html
@@ -67,6 +67,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -67,6 +67,7 @@
       <a href="/docs/packages/prompt-templates.html" class="sidebar-link">Prompt Templates</a>
       <a href="/docs/packages/claude-cli.html" class="sidebar-link">Claude Code CLI</a>
       <a href="/docs/packages/plannotator.html" class="sidebar-link">Plannotator</a>
+      <a href="/docs/packages/slopchop.html" class="sidebar-link">Slopchop</a>
       <a href="/docs/packages/powerbar.html" class="sidebar-link">Powerbar</a>
       <a href="/docs/packages/extension-settings.html" class="sidebar-link">Extension Settings</a>
       <a href="/docs/packages/usage.html" class="sidebar-link">Usage Tracker</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -857,6 +857,12 @@
         <div class="catalog-desc">Visual plan review and markdown annotation</div>
         <div class="catalog-author">by backnotprop</div>
       </a>
+      <a class="catalog-card" href="https://github.com/robzolkos/pi-slopchop" target="_blank" rel="noopener">
+        <span class="catalog-tag ui">ui</span>
+        <div class="catalog-name">pi-slopchop</div>
+        <div class="catalog-desc">Terminal-native diff review with FIX and DISCUSS annotations</div>
+        <div class="catalog-author">by robzolkos</div>
+      </a>
       <a class="catalog-card" href="https://github.com/juanibiapina/pi-powerbar" target="_blank" rel="noopener">
         <span class="catalog-tag ui">ui</span>
         <div class="catalog-name">pi-powerbar</div>


### PR DESCRIPTION
## Summary
- add pi-slopchop to the LazyPi package catalog
- add Slopchop docs, package index card, sidebar links, and homepage catalog entry
- add AGENTS.md project guidance with Conventional Commits note

## Testing
- npm test
- git diff --check