### PR TITLE
feat: add Short Pi videos section

### DIFF
--- a/.agents/skills/add-video/SKILL.md
+++ b/.agents/skills/add-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-video
-description: Add a new YouTube video to the LazyPi videos page. Use when given a YouTube URL to add to the site. Fetches title, channel, duration, and publish date automatically via agent-browser, then asks the user which category to place it in.
+description: Add a new YouTube video to the LazyPi videos page. Use when given a YouTube URL to add to the site. Fetches title, channel, duration, and publish date automatically via agent-browser; Shorts are placed in Short Pi automatically, while regular videos ask for a category.
 ---
 
 # Add Video to LazyPi
@@ -17,9 +17,9 @@ Pi appends the command arguments to this skill as `User: <args>`.
 
 ## Goal
 
-Add a YouTube video to `docs/_data/videos.yml` with all metadata fetched automatically, inserted in the correct category and sorted in reverse chronological order.
+Add a YouTube video to `docs/_data/videos.yml` with all metadata fetched automatically, inserted in the correct category and sorted in reverse chronological order. YouTube Shorts belong in the `Short Pi` category at the bottom of the videos page.
 
-## Step 1: Extract the video ID
+## Step 1: Extract the video ID and detect Shorts
 
 Parse the YouTube URL to extract the video ID.
 
@@ -27,6 +27,8 @@ Supported formats:
 - `https://www.youtube.com/watch?v=VIDEO_ID`
 - `https://youtu.be/VIDEO_ID`
 - `https://www.youtube.com/shorts/VIDEO_ID`
+
+If the provided URL path contains `/shorts/VIDEO_ID`, mark the video as a Short. Shorts always go in the `Short Pi` category and do not require a category prompt.
 
 ## Step 2: Fetch metadata via agent-browser
 
@@ -37,7 +39,7 @@ agent-browser open "https://www.youtube.com/watch?v=VIDEO_ID"
 agent-browser eval "JSON.stringify({ title: document.querySelector('meta[name=title]')?.content || document.title.replace(/ - YouTube$/, ''), channel: document.querySelector('span[itemprop=author] link[itemprop=name]')?.getAttribute('content') || document.querySelector('meta[itemprop=channelId]')?.content, duration: document.querySelector('meta[itemprop=duration]')?.content, published: document.querySelector('meta[itemprop=datePublished]')?.content })"
 ```
 
-The oEmbed API (`https://www.youtube.com/oembed?url=URL&format=json`) is a reliable fallback for `title` and `author_name` (channel) if agent-browser returns unexpected values.
+The oEmbed API (`https://www.youtube.com/oembed?url=URL&format=json`) is a reliable fallback for `title` and `author_name` (channel) if agent-browser returns unexpected values. Use the original Shorts URL for the oEmbed URL when the provided URL was a Short.
 
 ### Convert the raw values
 
@@ -49,11 +51,13 @@ The oEmbed API (`https://www.youtube.com/oembed?url=URL&format=json`) is a relia
 
 **published** — YouTube returns a full ISO 8601 timestamp (e.g. `2026-04-18T04:03:51-07:00`). Truncate to the date portion only: `2026-04-18`.
 
-## Step 3: Present the category list and ask the user
+## Step 3: Choose the category
 
-Read `docs/_data/videos.yml` to get the current categories in order. Present them as a numbered list:
+If the provided URL is a Short, set the category to `Short Pi` and skip the user prompt.
 
-```
+For regular YouTube videos, read `docs/_data/videos.yml` to get the current categories in order, excluding `Short Pi`. Present them as a numbered list:
+
+```text
 Which category should this video go in?
 
 1. Intro to Pi
@@ -68,7 +72,7 @@ Use `AskUserQuestion` (or equivalent interactive prompt) to get the user's choic
 
 ## Step 4: Insert into the YAML
 
-Read `docs/_data/videos.yml`. Find the chosen category block and insert the new video entry **at the top of that category's `videos:` list** (newest-first ordering).
+Read `docs/_data/videos.yml`. Find the chosen category block and insert the new video entry **at the top of that category's `videos:` list** (newest-first ordering). For Shorts, find the `Short Pi` category block.
 
 Entry format:
 ```yaml
@@ -97,3 +101,4 @@ Tell the user what was added:
 - Do not add a video that already exists in the YAML (check by `id` before inserting).
 - If agent-browser cannot fetch a field, ask the user for it rather than leaving it blank.
 - The YAML file is the single source of truth — no other files need updating when adding a video.
+- `Short Pi` should stay as the final category in `docs/_data/videos.yml` so it appears at the bottom of the videos page.

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -12,11 +12,6 @@
       channel: DevOps Toolbox
       duration: "13:53"
       published: "2026-04-24"
-    - id: 0uI62Ajzx08
-      title: "Pi: The Extensible Open Source Coding Agent"
-      channel: Seibert Group
-      duration: "0:38"
-      published: "2026-04-21"
     - id: hV_hnPJ2r6k
       title: "How to Use Pi as a Coding Agent (Standalone + SDK Basics)"
       channel: Vilson Vieira
@@ -97,3 +92,18 @@
       channel: Mayank Gupta
       duration: "1:30:42"
       published: "2026-03-28"
+
+- category: Short Pi
+  id: shortpi
+  description: "Quick Pi clips and YouTube Shorts."
+  videos:
+    - id: iAQq0MndX9c
+      title: "Pi can run from your phone!"
+      channel: DevOps Toolbox
+      duration: "0:36"
+      published: "2026-04-30"
+    - id: 0uI62Ajzx08
+      title: "Pi: The Extensible Open Source Coding Agent"
+      channel: Seibert Group
+      duration: "0:38"
+      published: "2026-04-21"

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -2,11 +2,6 @@
   id: intro
   description: "Get started with Pi — introductions, tutorials, and setup guides."
   videos:
-    - id: DWWrLlM3gwQ
-      title: "Pi Coding Agent Setup After 2 Months"
-      channel: Eero Alvar
-      duration: "19:09"
-      published: "2026-04-27"
     - id: OMFIPv8a4qA
       title: "Pi: The Minimal Agent for REAL Devs"
       channel: DevOps Toolbox
@@ -72,6 +67,11 @@
   id: advanced
   description: "Deep dives into advanced Pi workflows and techniques."
   videos:
+    - id: DWWrLlM3gwQ
+      title: "Pi Coding Agent Setup After 2 Months"
+      channel: Eero Alvar
+      duration: "19:09"
+      published: "2026-04-27"
     - id: M30gp1315Y4
       title: "One Agent Is NOT ENOUGH: Agentic Coding BEYOND Claude Code"
       channel: IndyDevDan

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -12,6 +12,11 @@
       channel: DevOps Toolbox
       duration: "13:53"
       published: "2026-04-24"
+    - id: jTMI1bCv3Ts
+      title: "Pi Coding Agent: The only Agent That's Truly YOURS"
+      channel: Igor Kudryk (Salesforce)
+      duration: "18:35"
+      published: "2026-04-10"
     - id: hV_hnPJ2r6k
       title: "How to Use Pi as a Coding Agent (Standalone + SDK Basics)"
       channel: Vilson Vieira

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -37,6 +37,11 @@
       channel: Julian Goldie SEO
       duration: "9:40"
       published: "2026-03-03"
+    - id: AEmHcFH1UgQ
+      title: "Claude Code is overkill - Pi is All you Need"
+      channel: Syntax
+      duration: "58:00"
+      published: "2026-02-04"
 
 - category: Full Course Pi
   id: fullcourse

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -92,6 +92,11 @@
       channel: Eero Alvar
       duration: "19:09"
       published: "2026-04-27"
+    - id: jD_MpL9xkSU
+      title: "pi and the Spec Paradox by Max Sumrall"
+      channel: Devoxx
+      duration: "12:29"
+      published: "2026-04-09"
     - id: M30gp1315Y4
       title: "One Agent Is NOT ENOUGH: Agentic Coding BEYOND Claude Code"
       channel: IndyDevDan

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -42,6 +42,11 @@
       channel: Maximilian Schwarzmüller
       duration: "15:25"
       published: "2026-03-12"
+    - id: hv0V0GJpC78
+      title: "Pi Coding Agent: RIP Claude Code & OpenCode! This Opensource Coding Agent is JUST WAY BETTER!"
+      channel: AICodeKing
+      duration: "14:08"
+      published: "2026-03-05"
     - id: boSPk_Ig4gU
       title: "Ollama + Pi: FREE Local AI Coding Agent"
       channel: Julian Goldie SEO

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -82,6 +82,11 @@
       channel: AI Engineer
       duration: "18:25"
       published: "2026-04-16"
+    - id: vXyerrv8ohw
+      title: "Pi Coding Agent - Interviewing the Creator of Openclaws core"
+      channel: 0xSero
+      duration: "55:36"
+      published: "2026-04-04"
     - id: Dli5slNaJu0
       title: "I Hated Every Coding Agent, So I Built My Own — Mario Zechner"
       channel: Mastra

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -32,6 +32,11 @@
       channel: Ben Davis
       duration: "22:03"
       published: "2026-04-01"
+    - id: fdbXNWkpPMY
+      title: "A love letter to Pi | Lucas Meijer"
+      channel: Build Monumental
+      duration: "27:11"
+      published: "2026-03-25"
     - id: wVe3XOnio7M
       title: "The PI coding agent is so much more than just another amazing coding agent!"
       channel: Maximilian Schwarzmüller

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -42,6 +42,11 @@
       channel: Maximilian Schwarzmüller
       duration: "15:25"
       published: "2026-03-12"
+    - id: e5sRVJTQxK8
+      title: "Pi Coding Agent: Forget Claude Code & OpenCode — This Open Source Agent Is Insane"
+      channel: AI Stack Engineer
+      duration: "9:18"
+      published: "2026-03-08"
     - id: hv0V0GJpC78
       title: "Pi Coding Agent: RIP Claude Code & OpenCode! This Opensource Coding Agent is JUST WAY BETTER!"
       channel: AICodeKing

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -77,6 +77,11 @@
   id: advanced
   description: "Deep dives into advanced Pi workflows and techniques."
   videos:
+    - id: yHgHU75N5T8
+      title: "DeepSeek V4: SOTA Coding Agent at 12x Lower Cost"
+      channel: Alejandro AO
+      duration: "18:10"
+      published: "2026-04-28"
     - id: DWWrLlM3gwQ
       title: "Pi Coding Agent Setup After 2 Months"
       channel: Eero Alvar

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -102,6 +102,11 @@
       channel: IndyDevDan
       duration: "51:37"
       published: "2026-02-23"
+    - id: ANQ1IYsFM2s
+      title: "Building a Computer Game from Scratch With Opus and PI"
+      channel: Armin Ronacher
+      duration: "38:02"
+      published: "2026-01-08"
 
 - category: Slice of Pi
   id: slice

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -27,6 +27,11 @@
       channel: Ben Davis
       duration: "22:03"
       published: "2026-04-01"
+    - id: XzZgLDL0wZY
+      title: "I Found the Vim of AI Coding Agents"
+      channel: chantastic
+      duration: "14:05"
+      published: "2026-03-26"
     - id: fdbXNWkpPMY
       title: "A love letter to Pi | Lucas Meijer"
       channel: Build Monumental

--- a/docs/videos.html
+++ b/docs/videos.html
@@ -23,7 +23,12 @@ og_image: /og-videos.png
     {% if cat.description %}<p class="category-desc">{{ cat.description }}</p>{% endif %}
     <div class="video-grid">
       {% for video in cat.videos %}
-      <a class="video-card" href="https://www.youtube.com/watch?v={{ video.id }}" target="_blank" rel="noopener">
+      {% if cat.id == 'shortpi' %}
+      {% assign video_url = "https://www.youtube.com/shorts/" | append: video.id %}
+      {% else %}
+      {% assign video_url = "https://www.youtube.com/watch?v=" | append: video.id %}
+      {% endif %}
+      <a class="video-card" href="{{ video_url }}" target="_blank" rel="noopener">
         <div class="video-thumb">
           <img src="https://img.youtube.com/vi/{{ video.id }}/mqdefault.jpg" alt="{{ video.title }}" loading="lazy">
           <div class="play-icon">


### PR DESCRIPTION
## Summary
- add a dedicated Short Pi section at the bottom of the videos page
- move existing YouTube Shorts into Short Pi and add the new short
- update the add-video skill to auto-place Shorts without asking for a category

## Test
- cd docs && bundle exec jekyll build