### PR TITLE
fix: update Pi package namespace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pi
-        run: npm install -g @mariozechner/pi-coding-agent
+        run: npm install -g @earendil-works/pi-coding-agent
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -21,7 +21,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install pi
-        run: npm install -g @mariozechner/pi-coding-agent
+        run: npm install -g @earendil-works/pi-coding-agent
 
       - name: Install npm dependencies
         run: npm ci
@@ -51,7 +51,7 @@ jobs:
           node-version: 20
 
       - name: Install pi
-        run: npm install -g @mariozechner/pi-coding-agent
+        run: npm install -g @earendil-works/pi-coding-agent
 
       - name: Install npm dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LazyPi
 
-The [Pi](https://github.com/badlogic/pi-mono) coding agent is minimal by design. LazyPi is opinionated by design. Run one command and get a complete, curated Pi setup — everything selected by default, nothing to research, nothing to configure. Remove what you don't want later.
+The [Pi](https://github.com/earendil-works/pi-mono) coding agent is minimal by design. LazyPi is opinionated by design. Run one command and get a complete, curated Pi setup — everything selected by default, nothing to research, nothing to configure. Remove what you don't want later.
 
 ## Quick start
 

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -716,16 +716,16 @@ async function ensurePi(flags) {
 	if (hasCmd("pi")) return true;
 
 	log.warn("Could not find the `pi` command on PATH.");
-	const ok = flags.yes || (await confirm("Install Pi now with `npm install -g @mariozechner/pi-coding-agent`?", true));
+	const ok = flags.yes || (await confirm("Install Pi now with `npm install -g @earendil-works/pi-coding-agent`?", true));
 	if (!ok) {
 		log.error("Install Pi first, then re-run `npx @robzolkos/lazypi`.");
 		return false;
 	}
 
-	log.step("Installing Pi via `npm install -g @mariozechner/pi-coding-agent`");
-	const code = spawnCommand("npm", ["install", "-g", "@mariozechner/pi-coding-agent"], { stdio: "inherit" }).status;
+	log.step("Installing Pi via `npm install -g @earendil-works/pi-coding-agent`");
+	const code = spawnCommand("npm", ["install", "-g", "@earendil-works/pi-coding-agent"], { stdio: "inherit" }).status;
 	if (code !== 0) {
-		log.error("Failed to install Pi. On some systems a global npm install needs sudo:\n  sudo npm install -g @mariozechner/pi-coding-agent");
+		log.error("Failed to install Pi. On some systems a global npm install needs sudo:\n  sudo npm install -g @earendil-works/pi-coding-agent");
 		return false;
 	}
 


### PR DESCRIPTION
## Summary
- install Pi from the new @earendil-works package namespace
- update CI smoke installs to use @earendil-works/pi-coding-agent
- update the README Pi repository link

## Tests
- npm test
- node scripts/packed-cli-smoke.mjs

Publishing is left to the existing release-please workflow after merge.