### PR TITLE
feat: add missing Pi videos

### DIFF
--- a/.agents/skills/find-videos/SKILL.md
+++ b/.agents/skills/find-videos/SKILL.md
@@ -29,13 +29,17 @@ If the user does not provide a query, search YouTube for:
 Pi coding agent
 ```
 
-Also consider searching these variants if the first query has few results:
+Also search these variants before concluding there are no more candidates, because YouTube ranking can miss relevant uploads for the default query:
 
 ```text
+"Pi agent"
+"Pi Agent" coding
 "pi-coding-agent"
 "@earendil-works" Pi
 "Earendil Works" Pi agent
 ```
+
+The exact phrase `"Pi agent"` is required in the default workflow; do not skip it just because `Pi coding agent` returned results.
 
 Prefer recent, relevant videos about the Pi coding agent. Avoid unrelated Raspberry Pi, math pi, or generic AI coding videos unless they clearly mention the Pi coding agent.
 
@@ -46,6 +50,7 @@ When possible, use YouTube's upload-date filter for recent videos, then enforce 
 Only propose a candidate if it has at least one strong Pi coding-agent signal:
 
 - title, description, or transcript snippet says `Pi coding agent`
+- title, description, or transcript snippet says `Pi agent` in a software/coding-agent context
 - title, description, or transcript snippet says `pi-coding-agent`
 - title, description, channel, or page metadata mentions `Earendil Works` in connection with Pi
 - description links to `github.com/earendil-works/pi-coding-agent`

--- a/.agents/skills/find-videos/SKILL.md
+++ b/.agents/skills/find-videos/SKILL.md
@@ -117,7 +117,7 @@ agent-browser open "https://www.youtube.com/results?search_query=Pi%20coding%20a
 
 If needed, also try YouTube's recent upload filters from the UI through agent-browser. The final candidate list must still be filtered to videos published within the last 10 days.
 
-Use `agent-browser eval` to extract visible video results in one pass. Prefer extracting:
+For each query, scroll the results page before extracting. YouTube lazy-loads and re-ranks results, so a single first-viewport extraction can miss relevant videos. Scroll down several times until the result count stops increasing, or until you have inspected at least 60 video results for that query when available. Then use `agent-browser eval` to extract results. Prefer extracting:
 
 - video ID
 - title
@@ -132,6 +132,8 @@ Example extraction script, adapting selectors as needed:
 ```bash
 agent-browser eval "JSON.stringify([...document.querySelectorAll('ytd-video-renderer,ytd-rich-item-renderer')].map((el) => { const link = el.querySelector('a#video-title,a.yt-simple-endpoint[href*=watch],a[href*=shorts]'); const href = link?.href || ''; const url = href.startsWith('http') ? href : new URL(href, location.origin).href; const id = new URL(url).searchParams.get('v') || url.match(/shorts\\/([^?&/]+)/)?.[1] || ''; const title = (link?.textContent || link?.getAttribute('title') || '').trim(); const channel = (el.querySelector('ytd-channel-name a,#channel-name a')?.textContent || '').trim(); const meta = [...el.querySelectorAll('#metadata-line span')].map((s) => s.textContent.trim()).filter(Boolean); const duration = (el.querySelector('ytd-thumbnail-overlay-time-status-renderer span,span.ytd-thumbnail-overlay-time-status-renderer')?.textContent || '').trim(); return { id, title, channel, url, duration, meta, isShort: url.includes('/shorts/') }; }).filter((v) => v.id && v.title))"
 ```
+
+If a known-relevant result is missing from the first extraction, rerun the same query after additional scrolling and try a related exact phrase (for example `"Pi Coding Agent"`, `"Pi agent"`, `"picodingagent"`, or `"Pi.dev" coding`). YouTube results are volatile; do not assume the first page is exhaustive.
 
 If YouTube blocks or returns incomplete results, use the normal browser page manually through agent-browser, or try a more specific search query. Do not use guessed metadata.
 

--- a/.agents/skills/find-videos/SKILL.md
+++ b/.agents/skills/find-videos/SKILL.md
@@ -32,14 +32,17 @@ Pi coding agent
 Also search these variants before concluding there are no more candidates, because YouTube ranking can miss relevant uploads for the default query:
 
 ```text
+"Pi Coding Agent"
 "Pi agent"
 "Pi Agent" coding
+"picodingagent"
+"Pi.dev" coding
 "pi-coding-agent"
 "@earendil-works" Pi
 "Earendil Works" Pi agent
 ```
 
-The exact phrase `"Pi agent"` is required in the default workflow; do not skip it just because `Pi coding agent` returned results.
+The exact phrases `"Pi Coding Agent"` and `"Pi agent"`, plus `"picodingagent"` and `"Pi.dev" coding`, are required in the default workflow; do not skip them just because `Pi coding agent` returned results.
 
 Prefer recent, relevant videos about the Pi coding agent. Avoid unrelated Raspberry Pi, math pi, or generic AI coding videos unless they clearly mention the Pi coding agent.
 

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -7,6 +7,11 @@
       channel: AI with Eric
       duration: "10:46"
       published: "2026-05-11"
+    - id: VEehKa__op8
+      title: "Pi Coding Agent: The Open-Source Tool That Modifies Itself #picodingagent #claudecode #opensourceai"
+      channel: FluxStack
+      duration: "10:13"
+      published: "2026-05-06"
     - id: N30XGyPrr6I
       title: "Pi Agent – Crash Course | Minimal Coding Agent"
       channel: Alejandro AO

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -2,16 +2,36 @@
   id: intro
   description: "Get started with Pi — introductions, tutorials, and setup guides."
   videos:
+    - id: hvqiRdGko6g
+      title: "Pi AI Agent and Coding Harness: Free, Open Source, Local, and Scary Good"
+      channel: AI with Eric
+      duration: "10:46"
+      published: "2026-05-11"
     - id: N30XGyPrr6I
       title: "Pi Agent – Crash Course | Minimal Coding Agent"
       channel: Alejandro AO
       duration: "26:34"
       published: "2026-05-05"
+    - id: 8yac_swVw8I
+      title: "Pi Coding Agent: The Minimal Coding Agent That Beats Claude Code and OpenCode"
+      channel: AI Stack Engineer
+      duration: "8:19"
+      published: "2026-05-03"
     - id: OMFIPv8a4qA
       title: "Pi: The Minimal Agent for REAL Devs"
       channel: DevOps Toolbox
       duration: "13:53"
       published: "2026-04-24"
+    - id: C5wEcJRo_VA
+      title: "Is PI Better Than OpenCode For AI Coding?"
+      channel: AI Automation Station
+      duration: "9:07"
+      published: "2026-04-23"
+    - id: O-96yYDPMOc
+      title: "Pi Coding Agent"
+      channel: DevOnDuty
+      duration: "9:55"
+      published: "2026-04-12"
     - id: jTMI1bCv3Ts
       title: "Pi Coding Agent: The only Agent That's Truly YOURS"
       channel: Igor Kudryk (Salesforce)
@@ -42,6 +62,11 @@
       channel: Build Monumental
       duration: "27:11"
       published: "2026-03-25"
+    - id: KMTcJX89jFI
+      title: "Pi Coding Agent: The Unrestricted Alternative to Claude Code"
+      channel: Zero Code Devs
+      duration: "7:57"
+      published: "2026-03-13"
     - id: wVe3XOnio7M
       title: "The PI coding agent is so much more than just another amazing coding agent!"
       channel: Maximilian Schwarzmüller
@@ -87,6 +112,11 @@
   id: advanced
   description: "Deep dives into advanced Pi workflows and techniques."
   videos:
+    - id: yBcmIoA-vGs
+      title: "Engineers, DELETE the BASH Tool: Agentic Security For Pi Agent and Claude Code"
+      channel: IndyDevDan
+      duration: "31:10"
+      published: "2026-05-11"
     - id: g94lMuhGlEY
       title: "PI Agent + Gemma 4 = Best Laptop AI Coding Setup!"
       channel: NetworkCoder
@@ -112,11 +142,26 @@
       channel: Eero Alvar
       duration: "19:09"
       published: "2026-04-27"
+    - id: XSmI7OYd7iM
+      title: "Pi Coding Agent + Archon: Build ANY AI Coding Workflow (No Claude Code Bloat)"
+      channel: Cole Medin
+      duration: "17:49"
+      published: "2026-04-20"
+    - id: 1ZsFjM6yZGI
+      title: "Don't sleep on the Pi agent, it solves the sandbox problem"
+      channel: marimo
+      duration: "6:55"
+      published: "2026-04-16"
     - id: jD_MpL9xkSU
       title: "pi and the Spec Paradox by Max Sumrall"
       channel: Devoxx
       duration: "12:29"
       published: "2026-04-09"
+    - id: ttklS6Yp0O8
+      title: "Gemma 4 with Pi Coding Agent & llama.cpp | Build LLM Resource Calculator with NextJS | 🔴 Live"
+      channel: Venelin Valkov
+      duration: "1:06:16"
+      published: "2026-04-07"
     - id: M30gp1315Y4
       title: "One Agent Is NOT ENOUGH: Agentic Coding BEYOND Claude Code"
       channel: IndyDevDan
@@ -127,6 +172,21 @@
       channel: IndyDevDan
       duration: "51:37"
       published: "2026-02-23"
+    - id: KiplOks4NAs
+      title: "300 Tokens vs 10K | Pi Wins Anyway"
+      channel: DIY Smart Code
+      duration: "10:30"
+      published: "2026-02-23"
+    - id: XqFun9XCXPw
+      title: "Pi Coding Agent - Visual Plan Mode Extension"
+      channel: Michael
+      duration: "2:58"
+      published: "2026-02-21"
+    - id: uPR7aAneg2U
+      title: "Short Demo of my Pi Todo Extension"
+      channel: Armin Ronacher
+      duration: "11:27"
+      published: "2026-01-25"
     - id: ANQ1IYsFM2s
       title: "Building a Computer Game from Scratch With Opus and PI"
       channel: Armin Ronacher
@@ -137,6 +197,11 @@
   id: slice
   description: "Talks, interviews, and discussions about Pi from the creator and community."
   videos:
+    - id: JM1sIVIZYRg
+      title: "State of Agentic Coding #6 with Armin and Ben"
+      channel: Armin Ronacher
+      duration: "1:38:23"
+      published: "2026-05-11"
     - id: sqtX2OmgOF0
       title: "Tokens can make you rich, just do this – Mario Zechner"
       channel: David Ondrej
@@ -167,6 +232,11 @@
       channel: Mayank Gupta
       duration: "1:30:42"
       published: "2026-03-28"
+    - id: 4p2uQ4FQtis
+      title: "pi - a radically minimal, opinionated multi-model coding agent"
+      channel: Mario Zechner
+      duration: "11:54"
+      published: "2025-11-12"
 
 - category: Short Pi
   id: shortpi

--- a/docs/_data/videos.yml
+++ b/docs/_data/videos.yml
@@ -12,10 +12,20 @@
       channel: FluxStack
       duration: "10:13"
       published: "2026-05-06"
+    - id: dGCFj-IcuI0
+      title: "Pi Coding Agent vs Claude Code, Codex & OpenCode"
+      channel: Panda Making Money
+      duration: "29:06"
+      published: "2026-05-06"
     - id: N30XGyPrr6I
       title: "Pi Agent – Crash Course | Minimal Coding Agent"
       channel: Alejandro AO
       duration: "26:34"
+      published: "2026-05-05"
+    - id: NQhH2fPcDmo
+      title: "Pi coding agent with claude"
+      channel: Music mix and remix
+      duration: "5:18"
       published: "2026-05-05"
     - id: 8yac_swVw8I
       title: "Pi Coding Agent: The Minimal Coding Agent That Beats Claude Code and OpenCode"
@@ -32,6 +42,16 @@
       channel: AI Automation Station
       duration: "9:07"
       published: "2026-04-23"
+    - id: 2s573tu8B7M
+      title: "PI CODING AGENT - ЧТО ЭТО? Минималистичный CLI для разработки"
+      channel: NullsCode
+      duration: "9:34"
+      published: "2026-04-22"
+    - id: qdJIBZ3ENfg
+      title: "Pi Coding Agent DESTROYS Openclaw?"
+      channel: AI News Today | Julian Goldie Podcast
+      duration: "11:45"
+      published: "2026-04-13"
     - id: O-96yYDPMOc
       title: "Pi Coding Agent"
       channel: DevOnDuty
@@ -102,6 +122,11 @@
   id: fullcourse
   description: "Extended videos showing it all."
   videos:
+    - id: 6T46BslVzAc
+      title: "Pi Coding Agent (Free Course) (2026)"
+      channel: Tutorials by Manizha & Ryan
+      duration: "19:13"
+      published: "2026-05-04"
     - id: yAPKzHrx3eo
       title: "Pi Agent (Full Course)"
       channel: Vilson Vieira
@@ -122,11 +147,21 @@
       channel: IndyDevDan
       duration: "31:10"
       published: "2026-05-11"
+    - id: JnQcPzjC6Vo
+      title: "I Gave Pi Access to Obsidian And I'm Not Looking Back"
+      channel: DevOps Toolbox
+      duration: "14:20"
+      published: "2026-05-08"
     - id: g94lMuhGlEY
       title: "PI Agent + Gemma 4 = Best Laptop AI Coding Setup!"
       channel: NetworkCoder
       duration: "13:30"
       published: "2026-05-07"
+    - id: qS-aMKbVJ00
+      title: "How the PI coding agent was built"
+      channel: The Manual for The Western Male
+      duration: "9:04"
+      published: "2026-05-06"
     - id: EnXKysJNz_8
       title: "GPT-5.5 VERIFIED Opus 4.7: A Pi Coding Agent That REVIEWS Like YOU"
       channel: IndyDevDan
@@ -137,6 +172,21 @@
       channel: Tech Friend AJ
       duration: "13:39"
       published: "2026-05-03"
+    - id: dRialfHHwRw
+      title: "DON'T WASTE SO MANY TOKENS! PI CODING AGENT vs OPENCODE with same local LLM."
+      channel: Luigi Tech
+      duration: "15:16"
+      published: "2026-05-03"
+    - id: _u4PLnc13ME
+      title: "Claude Code Wasted 100K Tokens. Pi Did It Better on Local Gemma 4"
+      channel: Execute Automation
+      duration: "19:10"
+      published: "2026-05-02"
+    - id: pn4hGl6GJ0I
+      title: "I Ran an Uncensored Local LLM Inside Pi Coding Agent (Qwen 3.6 + Gemma 4 uncensored live demo)"
+      channel: Luke Spear
+      duration: "35:19"
+      published: "2026-04-30"
     - id: yHgHU75N5T8
       title: "DeepSeek V4: SOTA Coding Agent at 12x Lower Cost"
       channel: Alejandro AO
@@ -152,26 +202,101 @@
       channel: Cole Medin
       duration: "17:49"
       published: "2026-04-20"
+    - id: 6MYOhD_XytA
+      title: "pi-reviewer: a pi coding agent extension to review pull requests via voice"
+      channel: 6etime with Arnav
+      duration: "6:40"
+      published: "2026-04-18"
     - id: 1ZsFjM6yZGI
       title: "Don't sleep on the Pi agent, it solves the sandbox problem"
       channel: marimo
       duration: "6:55"
       published: "2026-04-16"
+    - id: c9292MtK8EA
+      title: "Pi Agent + a Real Browser = This Is What Happened"
+      channel: Steel Browser
+      duration: "5:24"
+      published: "2026-04-14"
+    - id: lWbEq1dEqKg
+      title: "How Pi Mono Actually Works in Your App"
+      channel: Michael Jamieson
+      duration: "18:12"
+      published: "2026-04-12"
+    - id: _K4c7cL_tzw
+      title: "Coding Agent from Scratch: Terminal User Interface with pi-tui"
+      channel: Joe Maddalone
+      duration: "16:31"
+      published: "2026-04-12"
+    - id: BILOFt4a50k
+      title: "Pi Coding Agent - Oneshot Updating an Extension with Pi - CLI Streaming Mode (pi -p --stream=all)"
+      channel: Lotus Creation Concepts
+      duration: "5:10"
+      published: "2026-04-12"
+    - id: yqwT5sGSlJk
+      title: "Your Own Perplexity Deep Search Tool Using Pi Coding Agent"
+      channel: Lotus Creation Concepts
+      duration: "1:46"
+      published: "2026-04-11"
     - id: jD_MpL9xkSU
       title: "pi and the Spec Paradox by Max Sumrall"
       channel: Devoxx
       duration: "12:29"
+      published: "2026-04-09"
+    - id: 1cF_Afc5_tA
+      title: "PI Agent + Ollama + Gemma4: Super Lightweight and Highly Extensible AI Coding Agent"
+      channel: DevsKingdom
+      duration: "15:02"
       published: "2026-04-09"
     - id: ttklS6Yp0O8
       title: "Gemma 4 with Pi Coding Agent & llama.cpp | Build LLM Resource Calculator with NextJS | 🔴 Live"
       channel: Venelin Valkov
       duration: "1:06:16"
       published: "2026-04-07"
+    - id: RairMJflUSA
+      title: "My Pi Agent Teams. Claude Code Leak SIGNAL. Harness Engineering"
+      channel: IndyDevDan
+      duration: "32:27"
+      published: "2026-04-06"
+    - id: gsiOPy3jPDI
+      title: "Remote coding agents over SSH w/ Pi & tmux"
+      channel: Ben Vinegar
+      duration: "17:05"
+      published: "2026-04-04"
+    - id: YOuKskmEosQ
+      title: "How Pi Mono Actually Works: The Shared Agent Stack Behind Pi"
+      channel: Michael Jamieson
+      duration: "16:06"
+      published: "2026-04-02"
     - id: M30gp1315Y4
       title: "One Agent Is NOT ENOUGH: Agentic Coding BEYOND Claude Code"
       channel: IndyDevDan
       duration: "34:57"
       published: "2026-03-30"
+    - id: fgPJjvD5mDM
+      title: "Pi vs OpenCode - Which AI Coding Agent Should You Use?"
+      channel: KTG Analysis
+      duration: "17:42"
+      published: "2026-03-24"
+    - id: A_fvWhL-NIQ
+      title: "opencode vs pi agent. simple benchmark with Local LLM."
+      channel: Luigi Tech
+      duration: "7:38"
+      published: "2026-03-14"
+    - id: 28MLpm4NSBs
+      title: "Pi Coding Agent Custom Theme and Animated Gif During Thought"
+      channel: Dara Jeffus
+      duration: "3:14"
+      published: "2026-02-26"
+    - id: Fs_raupd3kc
+      title: "Context Bonsai Plugin development and more experimentation with the pi coding agent"
+      channel: Vibecodelicious
+      duration: "2:05:52"
+      published: "2026-02-26"
+    - id: y3ntCh8vF7Q
+      title: "PI: pi-coding-agent, a general framework"
+      channel: Kan Deng
+      duration: "10:47"
+      published: "2026-02-25"
     - id: f8cfH5XX-XU
       title: "The Pi Coding Agent: The ONLY REAL Claude Code COMPETITOR"
       channel: IndyDevDan
@@ -192,6 +317,11 @@
       channel: Armin Ronacher
       duration: "11:27"
       published: "2026-01-25"
+    - id: jiWS9pP_cX0
+      title: "eddo skill for pi-coding-agent teaser"
+      channel: Walter Rafelsberger
+      duration: "2:08"
+      published: "2026-01-13"
     - id: ANQ1IYsFM2s
       title: "Building a Computer Game from Scratch With Opus and PI"
       channel: Armin Ronacher
@@ -207,6 +337,16 @@
       channel: Armin Ronacher
       duration: "1:38:23"
       published: "2026-05-11"
+    - id: vAIDdLKB6-w
+      title: "A Piece of Pi: Embedding The OpenClaw Coding Agent In Your Product — Matthias Luebken, Tavon"
+      channel: AI Engineer
+      duration: "20:42"
+      published: "2026-05-11"
+    - id: BQ_Es8k650I
+      title: "Pi.dev explained by its creators | AI Agents Under the Hood"
+      channel: Merantix AI Campus
+      duration: "1:12:40"
+      published: "2026-05-05"
     - id: sqtX2OmgOF0
       title: "Tokens can make you rich, just do this – Mario Zechner"
       channel: David Ondrej
@@ -222,6 +362,11 @@
       channel: AI Engineer
       duration: "18:25"
       published: "2026-04-16"
+    - id: 3DNkDIVKtK8
+      title: "Crashing out at Anthropic and getting Pi pilled"
+      channel: Theo - t3․gg
+      duration: "1:21:48"
+      published: "2026-04-08"
     - id: vXyerrv8ohw
       title: "Pi Coding Agent - Interviewing the Creator of Openclaws core"
       channel: 0xSero
@@ -237,6 +382,16 @@
       channel: Mayank Gupta
       duration: "1:30:42"
       published: "2026-03-28"
+    - id: -uB0KVAQIM8
+      title: "Pi Coding Agent, Dark Factories & the Furniture Makers of Carolina"
+      channel: Artificial Developer Intelligence
+      duration: "1:25:17"
+      published: "2026-02-13"
+    - id: dWlhu0aWCb8
+      title: "Hacking pi, the little coding agent that could, using pi"
+      channel: Mario Zechner
+      duration: "2:13:21"
+      published: "2025-11-14"
     - id: 4p2uQ4FQtis
       title: "pi - a radically minimal, opinionated multi-model coding agent"
       channel: Mario Zechner
@@ -257,3 +412,8 @@
       channel: Seibert Group
       duration: "0:38"
       published: "2026-04-21"
+    - id: sQq8Bhqig5E
+      title: "Sync active nvim theme to pi coding agent"
+      channel: Lê Hùng Thiện
+      duration: "1:18"
+      published: "2026-04-10"


### PR DESCRIPTION
- add newly discovered Pi videos from expanded 12-month YouTube search
- add recent Pi agent security and State of Agentic Coding videos
- update the find-videos skill to include required Pi agent search terms
- validated videos YAML parses successfully
- checked for duplicate YouTube IDs