### PR TITLE
Remove pi-themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ That's it.  Once done - run `pi` and experience a feature rich coding agent expe
 
 Install is **idempotent** — LazyPi reads your Pi settings and skips any package that is already installed, so re-running is safe.
 
-For theme packages, LazyPi also applies a small Pi package filter so duplicate theme IDs do not collide. It keeps both `pi-themes` and `@victor-software-house/pi-curated-themes` installed, but excludes `catppuccin-mocha` and `gruvbox-dark` from `pi-themes` so those two come from the curated themes package.
-
 ## Commands
 
 | Command | What it does |

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -62,7 +62,6 @@ export const PACKAGES = [
 	},
 	{ id: "ralph-wiggum", category: "research", source: "npm:@tmustier/pi-ralph-wiggum", description: "Ralph Wiggum agent loop", hint: "Long-running iterative dev loops with goals, checklists, and optional self-reflection." },
 	{ id: "compound", category: "frameworks", source: "npm:@every-env/compound-plugin", description: "Official Compound Engineering", hint: "Official Every Pi target via Bun (skipped if Bun is unavailable)." },
-	{ id: "pi-themes", category: "themes", source: "npm:pi-themes", description: "Theme collection + picker", hint: "10 themes (Catppuccin, Dracula, Gruvbox, Nord, One Dark, Solarized, Tokyo Night) with a /themes picker command." },
 	{ id: "hackerman", category: "themes", source: "git:github.com/javierportillo/pi-hackerman@63b0a3ef2c7b14985ffeb6cac44614ba59cd5693", description: "Hackerman theme", hint: "Neon hacker-style color theme ported from the VS Code Hackerman Theme." },
 	{ id: "curated-themes", category: "themes", source: "npm:@victor-software-house/pi-curated-themes", description: "65 curated dark themes", hint: "65 dark terminal themes adapted from iTerm2-Color-Schemes." },
 	{ id: "terminal-theme", category: "themes", source: "npm:pi-terminal-theme", description: "Terminal ANSI theme", hint: "Maps Pi colors to ANSI 0–15 so Pi inherits your terminal's own color palette." },
@@ -284,14 +283,6 @@ function settingsPath(local) {
 // so they fall back to the user's active session model instead.
 const SUBAGENT_BUILTIN_MODELS = ["context-builder", "planner", "researcher", "reviewer", "scout", "worker"];
 
-const PI_THEMES_FILTERED_ENTRY = {
-	source: "npm:pi-themes",
-	themes: [
-		"themes/*.json",
-		"!themes/catppuccin-mocha.json",
-		"!themes/gruvbox-dark.json",
-	],
-};
 
 function readSettings(local) {
 	const path = settingsPath(local);
@@ -329,22 +320,6 @@ function writeSubagentOverrides(local) {
 		const overrides = {};
 		for (const name of SUBAGENT_BUILTIN_MODELS) overrides[name] = { model: "" };
 		settings.subagents = { ...(settings.subagents ?? {}), agentOverrides: { ...(settings.subagents?.agentOverrides ?? {}), ...overrides } };
-		return true;
-	});
-}
-
-function writePiThemesFilter(local) {
-	return writeSettings(local, (settings) => {
-		const packages = Array.isArray(settings.packages) ? [...settings.packages] : [];
-		const index = packages.findIndex((entry) => (typeof entry === "string" && entry === PI_THEMES_FILTERED_ENTRY.source)
-			|| (entry && typeof entry === "object" && entry.source === PI_THEMES_FILTERED_ENTRY.source));
-		if (index === -1) return false;
-		const entry = packages[index];
-		if (entry && typeof entry === "object" && Array.isArray(entry.themes)) return false;
-		packages[index] = entry && typeof entry === "object"
-			? { ...entry, themes: [...PI_THEMES_FILTERED_ENTRY.themes] }
-			: { ...PI_THEMES_FILTERED_ENTRY, themes: [...PI_THEMES_FILTERED_ENTRY.themes] };
-		settings.packages = packages;
 		return true;
 	});
 }
@@ -813,19 +788,6 @@ async function cmdInstall(flags) {
 	}
 
 	if (toInstall.length === 0) {
-		if (selected.some((p) => p.id === "pi-themes")) {
-			const themesFilterResult = writePiThemesFilter(flags.local);
-			if (!themesFilterResult.ok) {
-				const message = `Refusing to update ${themesFilterResult.path} because it is not valid JSON (${themesFilterResult.error}). Fix the file first, then rerun lazypi.`;
-				if (interactive) {
-					log.error(message);
-					outro(red("Aborted."));
-				} else {
-					console.error(red(message));
-				}
-				return 2;
-			}
-		}
 		printCheatsheet(selected, interactive);
 		const done = "Nothing to do — every selected package is already installed.";
 		if (interactive) log.success(green(done));
@@ -883,20 +845,6 @@ async function cmdInstall(flags) {
 			failed.push(pkg);
 			if (interactive) log.error(`failed to install ${pkg.id}`);
 			else console.error(red(`  ✗ failed to install ${pkg.id}`));
-		}
-	}
-
-	if (selected.some((p) => p.id === "pi-themes")) {
-		const themesFilterResult = writePiThemesFilter(flags.local);
-		if (!themesFilterResult.ok) {
-			const message = `Refusing to update ${themesFilterResult.path} because it is not valid JSON (${themesFilterResult.error}). Fix the file first, then rerun lazypi.`;
-			if (interactive) {
-				log.error(message);
-				outro(red("Aborted."));
-			} else {
-				console.error(red(message));
-			}
-			return 2;
 		}
 	}
 

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -18,7 +18,7 @@ description: "LazyPi documentation — one command to get a complete Pi coding a
     </p>
 
     <h2>What it installs</h2>
-    <p>LazyPi installs 26 hand-picked packages across five categories:</p>
+    <p>LazyPi installs 25 hand-picked packages across five categories:</p>
 
     <table>
       <thead>
@@ -34,7 +34,7 @@ description: "LazyPi documentation — one command to get a complete Pi coding a
         </tr>
         <tr>
           <td>Themes</td>
-          <td>76 terminal themes: Dracula, Nord, Gruvbox, Tokyo Night, and more</td>
+          <td>67 terminal themes: Kanagawa, Carbonfox, Gruvbox Dark, Hackerman, and more</td>
         </tr>
         <tr>
           <td>MCP</td>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -29,7 +29,7 @@ description: "How to install LazyPi and get your Pi coding agent set up."
 
     <h2>Install all vs. interactive picker</h2>
     <p>
-      Choosing <strong>Install all (recommended)</strong> installs all 26 packages at once. This is the fastest way to get a complete setup and is safe — each package is independent and none conflict.
+      Choosing <strong>Install all (recommended)</strong> installs all 25 packages at once. This is the fastest way to get a complete setup with LazyPi's curated package set.
     </p>
     <p>
       The interactive picker lets you browse the catalog and select only what you want. Use arrow keys to navigate, space to toggle, and enter to confirm.

--- a/docs/docs/packages/index.html
+++ b/docs/docs/packages/index.html
@@ -4,7 +4,7 @@ title: "Packages — LazyPi Docs"
 description: "The 21 non-theme packages included in LazyPi, with themes documented separately."
 ---
 <h1>Packages</h1>
-    <p class="page-desc">21 hand-picked non-theme packages from the Pi community. The 5 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
+    <p class="page-desc">21 hand-picked non-theme packages from the Pi community. The 3 bundled theme packages are documented separately on <a href="/themes.html">Themes</a>.</p>
 
     <div class="pkg-grid">
       <a class="pkg-card" href="/docs/packages/subagents.html">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: "LazyPi — One command. Full Pi setup."
-description: "Run one command and get a complete, curated Pi coding agent setup — 60+ skills, 76 themes, MCP servers, sub-agents, Claude Code CLI provider, memory, and more."
+description: "Run one command and get a complete, curated Pi coding agent setup — 60+ skills, 67 themes, MCP servers, sub-agents, Claude Code CLI provider, memory, and more."
 extra_css: /assets/css/index.css
 og_title: "LazyPi — The fastest way to fall in love with Pi."
-og_description: "One command installs 60+ community skills, 76 themes, MCP servers, Claude Code CLI provider, memory, and more. See what Pi is capable of before you spend an hour configuring it."
+og_description: "One command installs 60+ community skills, 67 themes, MCP servers, Claude Code CLI provider, memory, and more. See what Pi is capable of before you spend an hour configuring it."
 og_image: /og.png
 ---
 <!-- HERO -->
@@ -17,7 +17,7 @@ og_image: /og.png
   <h1>The fastest way to<br><em>fall in love</em> with Pi.</h1>
   <p class="hero-tagline">One command. Everything configured. Nothing to research.</p>
   <p class="hero-sub">
-    One command installs 60+ community skills, 76 themes, MCP support, sub-agent
+    One command installs 60+ community skills, 67 themes, MCP support, sub-agent
     support, Claude Code CLI provider support, memory, and more. You're left with a curated starting point that gets you an exciting, useful experience immediately, without the research and configuration tax.
   </p>
 
@@ -37,7 +37,7 @@ og_image: /og.png
       <div><span class="out-check">✔ </span><span class="out">pi-subagents installed</span></div>
       <div><span class="out-check">✔ </span><span class="out">pi-memory-md installed</span></div>
       <div><span class="out-check">✔ </span><span class="out">pi-mcp-adapter installed</span></div>
-      <div><span class="out-check">✔ </span><span class="out">76 themes installed</span></div>
+      <div><span class="out-check">✔ </span><span class="out">67 themes installed</span></div>
       <div><span class="out-check">✔ </span><span class="out">60+ skills ready</span></div>
       <div class="out">&nbsp;</div>
       <div><span class="out-hi">◆ </span><span class="out">Done. Run <span class="out-hi">pi</span> to get started.</span> <span class="cursor"></span></div>
@@ -284,8 +284,8 @@ og_image: /og.png
       </a>
       <a class="catalog-card" href="/themes.html">
         <span class="catalog-tag themes">themes</span>
-        <div class="catalog-name">76 themes</div>
-        <div class="catalog-desc">Dracula, Nord, Gruvbox, Tokyo Night, Kanagawa, and 73 more</div>
+        <div class="catalog-name">67 themes</div>
+        <div class="catalog-desc">Kanagawa, Carbonfox, Gruvbox Dark, Hackerman, and 63 more</div>
         <div class="catalog-author">by the community</div>
       </a>
     </div>

--- a/docs/themes.html
+++ b/docs/themes.html
@@ -5,8 +5,8 @@ extra_css: /assets/css/themes.css
 ---
 <div class="header">
   <p class="header-eyebrow">Installed with LazyPi</p>
-  <h1>75 Themes</h1>
-  <p>Every theme you get with <code style="color:var(--green)">npx @robzolkos/lazypi</code> — click any tile to preview. LazyPi filters duplicate theme IDs from <code style="color:var(--green)">pi-themes</code>, so <code style="color:var(--green)">catppuccin-mocha</code> and <code style="color:var(--green)">gruvbox-dark</code> are sourced from <code style="color:var(--green)">pi-curated-themes</code>.</p>
+  <h1>67 Themes</h1>
+  <p>Every theme you get with <code style="color:var(--green)">npx @robzolkos/lazypi</code> — click any tile to preview.</p>
 </div>
 
 <div class="filter-bar" id="filter-bar"></div>
@@ -26,7 +26,6 @@ const themes = [
   { name: "Box",                     pkg: "pi-curated-themes", bg: "#141d2b", fg: "#9fef00", swatches: ["#cc0403","#19cb00","#cecb00","#0d73cc","#cb1ed1","#0dcdcd"] },
   { name: "Brogrammer",              pkg: "pi-curated-themes", bg: "#131313", fg: "#d6dbe5", swatches: ["#f81118","#2dc55e","#ecba0f","#2a84d2","#4e5ab7","#1081d6"] },
   { name: "Carbonfox",               pkg: "pi-curated-themes", bg: "#161616", fg: "#f2f4f8", swatches: ["#ee5396","#25be6a","#08bdba","#78a9ff","#be95ff","#33b1ff"] },
-  { name: "Catppuccin Latte",        pkg: "pi-themes",         bg: "#eff1f5", fg: "#4c4f69", swatches: ["#d20f39","#40a02b","#df8e1d","#1e66f5","#8839ef","#04a5e5"] },
   { name: "Catppuccin Mocha",        pkg: "pi-curated-themes", bg: "#1e1e2e", fg: "#cdd6f4", swatches: ["#f38ba8","#a6e3a1","#f9e2af","#89b4fa","#cba6f7","#89dceb"] },
   { name: "Citruszest",              pkg: "pi-curated-themes", bg: "#121212", fg: "#bfbfbf", swatches: ["#ff5454","#00cc7a","#ffd400","#00bfff","#ff90fe","#48d1cc"] },
   { name: "Cursor Dark",             pkg: "pi-curated-themes", bg: "#141414", fg: "#d4d4d4", swatches: ["#fc6b83","#3fa266","#d2943e","#81a1c1","#b48ead","#88c0d0"] },
@@ -35,7 +34,6 @@ const themes = [
   { name: "Dark Pastel",             pkg: "pi-curated-themes", bg: "#000000", fg: "#ffffff", swatches: ["#ff5555","#55ff55","#ffff55","#5555ff","#ff55ff","#55ffff"] },
   { name: "Dimmed Monokai",          pkg: "pi-curated-themes", bg: "#1f1f1f", fg: "#b9bcba", swatches: ["#be3f48","#879a3b","#c5a635","#4f76a1","#855c8d","#578fa4"] },
   { name: "Doom Peacock",            pkg: "pi-curated-themes", bg: "#2b2a27", fg: "#ede0ce", swatches: ["#cb4b16","#26a6a6","#bcd42a","#2a6cc6","#a9a1e1","#5699af"] },
-  { name: "Dracula",                 pkg: "pi-themes",         bg: "#282a36", fg: "#f8f8f2", swatches: ["#ff5555","#50fa7b","#f1fa8c","#bd93f9","#ff79c6","#8be9fd"] },
   { name: "Dracula Plus",            pkg: "pi-curated-themes", bg: "#1e1523", fg: "#f8f8f2", swatches: ["#ff5555","#50fa7b","#f1fa8c","#9580ff","#ff79c6","#8be9fd"] },
   { name: "Earthsong",               pkg: "pi-curated-themes", bg: "#292520", fg: "#e5c7a9", swatches: ["#c94234","#85c54c","#f5ae2e","#1398b9","#d0633d","#509552"] },
   { name: "Everforest Dark Hard",    pkg: "pi-curated-themes", bg: "#1e2326", fg: "#d3c6aa", swatches: ["#e67e80","#a7c080","#dbbc7f","#7fbbb3","#d699b6","#83c092"] },
@@ -51,7 +49,6 @@ const themes = [
   { name: "Gruber Darker",           pkg: "pi-curated-themes", bg: "#181818", fg: "#e4e4e4", swatches: ["#ff0a36","#42dc00","#ffdb00","#92a7cb","#a095cb","#90aa9e"] },
   { name: "Gruvbox Dark",            pkg: "pi-curated-themes", bg: "#282828", fg: "#ebdbb2", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
   { name: "Gruvbox Dark Hard",       pkg: "pi-curated-themes", bg: "#1d2021", fg: "#ebdbb2", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
-  { name: "Gruvbox Light",           pkg: "pi-themes",         bg: "#fbf1c7", fg: "#3c3836", swatches: ["#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a"] },
   { name: "Gruvbox Material",        pkg: "pi-curated-themes", bg: "#1d2021", fg: "#d4be98", swatches: ["#ea6926","#c1d041","#eecf75","#6da3ec","#fd9bc1","#fe9d6e"] },
   { name: "Guezwhoz",                pkg: "pi-curated-themes", bg: "#1d1d1d", fg: "#d9d9d9", swatches: ["#e85181","#7ad694","#b7d074","#5aa0d6","#9a90e0","#58d6ce"] },
   { name: "Hackerman",               pkg: "pi-hackerman",      bg: "#0d0208", fg: "#00ff41", swatches: ["#ff0000","#00ff41","#ffff00","#003b00","#ff00ff","#00ffff"] },
@@ -71,17 +68,12 @@ const themes = [
   { name: "Matte Black",             pkg: "pi-curated-themes", bg: "#121212", fg: "#bebebe", swatches: ["#d35f5f","#ffc107","#b91c1c","#e68e0d","#d35f5f","#bebebe"] },
   { name: "Mellow",                  pkg: "pi-curated-themes", bg: "#161617", fg: "#c9c7cd", swatches: ["#f5a191","#90b99f","#e6b99d","#aca1cf","#e29eca","#ea83a5"] },
   { name: "Miasma",                  pkg: "pi-curated-themes", bg: "#222222", fg: "#c2c2b0", swatches: ["#685742","#5f875f","#b36d43","#78824b","#bb7744","#c9a554"] },
-  { name: "Nord",                    pkg: "pi-themes",         bg: "#2e3440", fg: "#d8dee9", swatches: ["#bf616a","#a3be8c","#ebcb8b","#81a1c1","#b48ead","#88c0d0"] },
   { name: "Nvim Dark",               pkg: "pi-curated-themes", bg: "#14161b", fg: "#e0e2ea", swatches: ["#ffc0b9","#b3f6c0","#fce094","#a6dbff","#ffcaff","#8cf8f7"] },
-  { name: "One Dark",                pkg: "pi-themes",         bg: "#282c34", fg: "#abb2bf", swatches: ["#e06c75","#98c379","#e5c07b","#61afef","#c678dd","#56b6c2"] },
   { name: "Popping and Locking",     pkg: "pi-curated-themes", bg: "#111114", fg: "#e0e0e0", swatches: ["#ff3c6f","#00e86e","#f9d71c","#1e90ff","#c75bff","#00d4ff"] },
   { name: "Sea Shells",              pkg: "pi-curated-themes", bg: "#09141b", fg: "#deb88d", swatches: ["#d15123","#027c9b","#fca02f","#1e4950","#68d4f1","#50a3b5"] },
   { name: "Sleepy Hollow",           pkg: "pi-curated-themes", bg: "#121214", fg: "#af9a91", swatches: ["#ba3934","#91773f","#b55600","#5f63b4","#a17c7b","#8faea9"] },
   { name: "Smyck",                   pkg: "pi-curated-themes", bg: "#1b1b1b", fg: "#f7f7f7", swatches: ["#b84131","#7da900","#c4a500","#62a3c4","#ba8acc","#207383"] },
-  { name: "Solarized Dark",          pkg: "pi-themes",         bg: "#002b36", fg: "#839496", swatches: ["#dc322f","#859900","#b58900","#268bd2","#d33682","#2aa198"] },
-  { name: "Solarized Light",         pkg: "pi-themes",         bg: "#fdf6e3", fg: "#657b83", swatches: ["#dc322f","#859900","#b58900","#268bd2","#d33682","#2aa198"] },
   { name: "Terminal (ANSI)",         pkg: "pi-terminal-theme", bg: "#000000", fg: "#ffffff", swatches: ["#cc0000","#4e9a06","#c4a000","#3465a4","#75507b","#06989a"] },
-  { name: "Tokyo Night",             pkg: "pi-themes",         bg: "#1a1b26", fg: "#a9b1d6", swatches: ["#f7768e","#9ece6a","#e0af68","#7aa2f7","#bb9af7","#7dcfff"] },
   { name: "Tomorrow Night",          pkg: "pi-curated-themes", bg: "#1d1f21", fg: "#c5c8c6", swatches: ["#cc6666","#b5bd68","#f0c674","#81a2be","#b294bb","#8abeb7"] },
   { name: "Tomorrow Night Bright",   pkg: "pi-curated-themes", bg: "#000000", fg: "#eaeaea", swatches: ["#d54e53","#b9ca4a","#e7c547","#7aa6da","#c397d8","#70c0b1"] },
   { name: "Tomorrow Night Burns",    pkg: "pi-curated-themes", bg: "#151515", fg: "#a1b0b8", swatches: ["#832e31","#a63c40","#d3494e","#fc595f","#df9395","#ba8586"] },
@@ -93,14 +85,12 @@ const themes = [
 
 const pkgLabels = {
   "pi-curated-themes": "curated",
-  "pi-themes":         "pi-themes",
   "pi-hackerman":      "hackerman",
   "pi-terminal-theme": "terminal",
 };
 
 const pkgColors = {
   "pi-curated-themes": "#7aa2f7",
-  "pi-themes":         "#4afa7a",
   "pi-hackerman":      "#00ff41",
   "pi-terminal-theme": "#888",
 };


### PR DESCRIPTION
Removes `pi-themes` from the LazyPi catalog to avoid the `ctrl+shift+t` shortcut conflict with `pi-autoresearch`. This keeps install-all from including both extensions that register the same shortcut.

Closes #49.