### PR TITLE
docs: point theme selection to settings

### DIFF
--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -40,8 +40,8 @@ pi</code></pre>
     </p>
 
     <h3>Change the theme</h3>
-    <pre><code>/themes</code></pre>
-    <p>Pick from the 76 included themes and immediately change the look of Pi.</p>
+    <pre><code>/settings</code></pre>
+    <p>Open Pi's built-in settings menu, choose <strong>Theme</strong>, then pick from the 67 included themes to immediately change the look of Pi. See the <a href="https://pi.dev/docs/latest/themes#selecting-a-theme" target="_blank" rel="noopener">Pi theme selection docs</a> for details.</p>
 
     <h3>Use plan mode on a real task</h3>
     <pre><code>/plan review this repository and propose the 3 highest-leverage improvements</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@ og_image: /og.png
     <div class="stat-label">Skills</div>
   </div>
   <div class="stat">
-    <div class="stat-num">76</div>
+    <div class="stat-num">67</div>
     <div class="stat-label">Themes</div>
   </div>
   <div class="stat">
@@ -94,7 +94,7 @@ og_image: /og.png
         <tr>
           <td>Themes</td>
           <td><span class="val-dim">2</span></td>
-          <td><span class="val">76</span></td>
+          <td><span class="val">67</span></td>
         </tr>
         <tr>
           <td>MCP server integration</td>


### PR DESCRIPTION
## Summary

This updates the First Steps docs after the removal of `pi-themes` from the default LazyPi catalog.

`pi-themes` was the package that provided the old theme picker command referenced by the docs. LazyPi now installs theme packages that provide the themes themselves, while theme selection is handled by Pi's built-in `/settings` menu.

## Changes

- Replace the stale `/themes` instruction with `/settings`
- Explain that users should choose **Theme** in Pi's built-in settings menu
- Link to the official Pi theme selection docs
- Correct remaining homepage theme counts from 76 to 67

Closes #53
