### PR TITLE
fix: delegate lazypi update to pi update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install is **idempotent** — LazyPi reads your Pi settings and skips any packag
 | `npx @robzolkos/lazypi` | Install all or selected catalog (interactive picker by default) |
 | `npx @robzolkos/lazypi remove <id>` | Remove a catalog package by id (or pass a raw pi source) |
 | `npx @robzolkos/lazypi status` | Show which catalog packages are installed, missing, or extra |
-| `npx @robzolkos/lazypi update` | Reconcile the catalog and then run `pi update` |
+| `npx @robzolkos/lazypi update` | Run `pi update` for installed Pi packages |
 | `npx @robzolkos/lazypi doctor` | Check your environment for common problems |
 
 ## Updating

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -223,7 +223,7 @@ ${bold("Commands:")}
   install   Install the selected LazyPi catalog (default)
   remove    Remove a catalog package by id (or pass a raw pi source)
   status    Show which catalog packages are installed
-  update    Re-reconcile the catalog and run \`pi update\`
+  update    Run \`pi update\` for installed Pi packages
   doctor    Check your environment for common problems
 
 ${bold("Install options:")}
@@ -1076,21 +1076,16 @@ function cmdStatus(flags) {
 	return 0;
 }
 
-function updateLocalPiPackages(local) {
-	const { sources, error } = readInstalledSources(local);
-	if (error) {
-		console.error(red(`Could not parse ${settingsPath(local)} — ${error}`));
-		return 1;
-	}
-	for (const source of sources) {
-		console.log(`\n→ pi install ${source}`);
-		const env = source.startsWith("git:")
-			? { ...process.env, npm_config_ignore_scripts: "true" }
-			: process.env;
-		const installStatus = spawnCommand("pi", ["install", "-l", source], { stdio: "inherit", env }).status ?? 1;
-		if (installStatus !== 0) return installStatus;
-	}
-	return 0;
+function resolveUpdateCatalogIds(flags) {
+	const { sources, error } = readInstalledSources(flags.local);
+	if (error) return { ids: [], error };
+	const selectedIds = resolveSelection(flags);
+	return {
+		ids: PACKAGES
+			.filter((pkg) => selectedIds.has(pkg.id) && isPackagePresent(pkg, sources, flags.local))
+			.map((pkg) => pkg.id),
+		error: null,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -1099,12 +1094,29 @@ function updateLocalPiPackages(local) {
 async function cmdUpdate(flags) {
 	if (!(await ensurePi(flags))) return 127;
 
-	console.log(bold("Step 1/2: reconcile LazyPi catalog"));
-	const installCode = await cmdInstall({ ...flags, command: "install", yes: true, forceIds: [COMPOUND_PKG_ID] });
-	if (installCode !== 0) return installCode;
+	const updateSelection = resolveUpdateCatalogIds(flags);
+	if (updateSelection.error) {
+		console.error(red(`Could not parse ${settingsPath(flags.local)} — ${updateSelection.error}`));
+		return 1;
+	}
 
-	console.log(bold(flags.local ? "\nStep 2/2: pi update" : "\nStep 2/2: update Pi core and extensions"));
-	return flags.local ? updateLocalPiPackages(true) : updatePiCoreAndExtensions();
+	if (updateSelection.ids.includes(COMPOUND_PKG_ID)) {
+		console.log(bold("Step 1/2: refresh Compound Engineering"));
+		const installCode = await cmdInstall({
+			...flags,
+			command: "install",
+			yes: true,
+			only: [COMPOUND_PKG_ID],
+			except: null,
+			forceIds: [COMPOUND_PKG_ID],
+		});
+		if (installCode !== 0) return installCode;
+		console.log(bold("\nStep 2/2: pi update"));
+	} else {
+		console.log(bold("pi update"));
+	}
+
+	return runPi(flags.local ? ["update", "--extensions"] : ["update"]);
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -88,7 +88,7 @@ pi</code></pre>
     <h2>6. Update later</h2>
     <pre><code>npx @robzolkos/lazypi update</code></pre>
     <p>
-      Reconcile your installed packages with the current LazyPi catalog and pull in upstream updates.
+      Run Pi's updater to pull in upstream updates for installed packages.
     </p>
 
     <h2>7. Diagnose issues</h2>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -92,7 +92,7 @@ description: "LazyPi documentation — one command to get a complete Pi coding a
         </tr>
         <tr>
           <td><code>npx @robzolkos/lazypi update</code></td>
-          <td>Update all installed LazyPi packages</td>
+          <td>Run <code>pi update</code> for installed packages</td>
         </tr>
         <tr>
           <td><code>npx @robzolkos/lazypi remove</code></td>

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -6,24 +6,23 @@ description: "How to update your LazyPi packages."
 <h1>Updating</h1>
     <p class="page-desc">Keep your LazyPi packages current.</p>
 
-    <h2>Update all packages</h2>
+    <h2>Update installed packages</h2>
     <pre><code>npx @robzolkos/lazypi update</code></pre>
     <p>
-      This reconciles the LazyPi catalog against what's currently installed and runs <code>pi update</code> for each package that has a newer version available.
+      This runs Pi's updater for installed package changes.
     </p>
 
     <h2>What the update does</h2>
     <p>
-      LazyPi maintains a catalog of the exact packages and versions it manages. When you run <code>update</code>, it:
+      When you run <code>update</code>, LazyPi:
     </p>
     <ol>
-      <li>Compares the current catalog against your installed packages</li>
-      <li>Identifies packages with newer versions</li>
-      <li>Runs <code>pi update</code> for each one</li>
+      <li>Refreshes Compound Engineering when it is installed</li>
+      <li>Runs <code>pi update</code> for installed Pi packages</li>
       <li>Reports what changed</li>
     </ol>
     <p>
-      Packages you installed outside of LazyPi are not touched.
+      Update preserves your selected catalog footprint.
     </p>
 
     <nav class="prev-next">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -68,7 +68,7 @@ extra_css: /assets/css/faq.css
   <div class="faq-item">
     <div class="faq-q">How do I keep everything up to date?</div>
     <div class="faq-a">
-      Run <code>npx @robzolkos/lazypi update</code>. This reconciles your installed packages against the latest catalog and then runs <code>pi update</code> to pull in any upstream changes.
+      Run <code>npx @robzolkos/lazypi update</code>. This runs Pi's updater to pull in upstream changes for installed Pi packages.
     </div>
   </div>
 

--- a/test/compound-migration.test.mjs
+++ b/test/compound-migration.test.mjs
@@ -122,7 +122,7 @@ compoundTest("legacy LazyPi state migrates to CE3 on real update flow", { timeou
 
 	const updateResult = runCli(["update", "-l", "--only", "compound"], { cwd: workspace, home });
 	assertSuccess(updateResult, "migration update failed");
-	assert.match(updateResult.stdout, /Step 1\/2: reconcile LazyPi catalog/);
+	assert.match(updateResult.stdout, /Step 1\/2: refresh Compound Engineering/);
 	assert.match(updateResult.stdout, /Step 2\/2: pi update/);
 	assert.match(updateResult.stdout, /@every-env\/compound-plugin@3\.0\.0/);
 

--- a/test/update-selection.test.mjs
+++ b/test/update-selection.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = resolve("bin/lazypi.mjs");
+const AUTH_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"TOGETHER_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+];
+
+function createWorkspace() {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-update-"));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+	const bin = join(root, "bin");
+	mkdirSync(join(workspace, ".pi"), { recursive: true });
+	mkdirSync(home, { recursive: true });
+	mkdirSync(bin, { recursive: true });
+	return { root, home, workspace, bin };
+}
+
+function writeFakePi(bin, callsPath) {
+	const piPath = join(bin, "pi");
+	writeFileSync(piPath, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${callsPath}"\nexit 0\n`);
+	chmodSync(piPath, 0o755);
+}
+
+function runCli(args, { cwd, home, bin } = {}) {
+	const env = {
+		...process.env,
+		HOME: home,
+		PATH: [bin, "/usr/bin", "/bin"].join(delimiter),
+	};
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		cwd,
+		env,
+		encoding: "utf8",
+		timeout: 60_000,
+	});
+	if (result.error) throw result.error;
+	return result;
+}
+
+test("update delegates to pi update without installing the full catalog", () => {
+	const { root, home, workspace, bin } = createWorkspace();
+	const callsPath = join(root, "pi-calls.log");
+	writeFakePi(bin, callsPath);
+	mkdirSync(join(home, ".pi", "agent"), { recursive: true });
+	writeFileSync(join(home, ".pi", "agent", "settings.json"), JSON.stringify({ packages: ["npm:pi-subagents"] }, null, 2) + "\n");
+
+	const result = runCli(["update"], { cwd: workspace, home, bin });
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.match(result.stdout, /pi update/);
+
+	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+	assert.deepEqual(calls, ["update"]);
+	assert.doesNotMatch(calls.join("\n"), /install|npm:pi-mcp-adapter|npm:pi-web-access|npm:@devkade\/pi-plan/);
+});


### PR DESCRIPTION
## Summary
- Change `lazypi update` to delegate normal package updates to `pi update` instead of re-running the LazyPi install flow.
- Preserve the LazyPi-managed Compound Engineering refresh/migration step when Compound is installed, then continue to Pi's updater.
- Update docs/help text so update is described as preserving the user's installed package footprint.
- Add a regression test that verifies update calls `pi update` and does not install missing catalog packages.

## Intent
`lazypi update` should update what the user already has installed. Users who selected only part of the catalog should not receive the rest of the catalog during an update.

Closes #62

## Tests
- `npm test`