### PR TITLE
fix: repair extension settings load order

### DIFF
--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -45,8 +45,8 @@ export const PACKAGES = [
 	{ id: "claude-cli", category: "core", source: "npm:pi-claude-cli", description: "Claude Code CLI provider", hint: "Use Claude Code CLI auth as a Pi model provider." },
 	{ id: "plannotator", category: "ui", source: "npm:@plannotator/pi-extension", description: "Planning and annotation workflow", hint: "Plan + annotate large changes interactively." },
 	{ id: "slopchop", category: "ui", source: "npm:pi-slopchop", description: "Diff review and annotation", hint: "Review diffs inside Pi and turn FIX/DISCUSS annotations into the next prompt." },
-	{ id: "powerbar", category: "ui", source: "npm:@juanibiapina/pi-powerbar", description: "Powerbar UI", hint: "Status line for Pi with live context." },
 	{ id: "extension-settings", category: "ui", source: "npm:@juanibiapina/pi-extension-settings", description: "Settings support for powerbar", hint: "Required by powerbar for its settings panel." },
+	{ id: "powerbar", category: "ui", source: "npm:@juanibiapina/pi-powerbar", description: "Powerbar UI", hint: "Status line for Pi with live context." },
 	{ id: "usage", category: "ui", source: "npm:@tmustier/pi-usage-extension", description: "Usage and cost dashboard", hint: "Track token usage and API cost in-session." },
 	{ id: "raw-paste", category: "ui", source: "npm:@tmustier/pi-raw-paste", description: "Raw paste command", hint: "Paste raw clipboard content without Pi re-interpreting it." },
 	{ id: "todos", category: "ui", source: "git:github.com/tintinweb/pi-manage-todo-list@b75c449aa85ce328e9a8b632f62bf642aed40359", description: "Todo list management", hint: "Track multi-step work with live progress widget and session persistence." },
@@ -77,6 +77,7 @@ const COMPOUND_DEPENDENCY_IDS = ["subagents", "pi-ask-user"];
 const COMPOUND_MANIFEST_RELATIVE_PATH = join("compound-engineering", "install-manifest.json");
 const COMPOUND_LEGACY_STATE_RELATIVE_PATH = join(".lazypi", "compound-engineering.json");
 const PACKAGE_DEPENDENCIES = new Map([[COMPOUND_PKG_ID, COMPOUND_DEPENDENCY_IDS]]);
+const LOAD_FIRST_PACKAGE_IDS = ["extension-settings"];
 
 // ---------------------------------------------------------------------------
 // Output helpers
@@ -326,16 +327,85 @@ function writeSubagentOverrides(local) {
 	});
 }
 
+function packageEntrySource(entry) {
+	if (typeof entry === "string") return entry;
+	if (entry && typeof entry === "object" && typeof entry.source === "string") return entry.source;
+	return null;
+}
+
 function readInstalledSources(local) {
 	const current = readSettings(local);
 	if (!current.exists) return { sources: new Set(), path: current.path, exists: false };
 	if (current.error) return { sources: new Set(), path: current.path, exists: true, error: current.error };
 	const sources = new Set();
 	for (const entry of current.parsed?.packages ?? []) {
-		if (typeof entry === "string") sources.add(entry);
-		else if (entry && typeof entry === "object" && typeof entry.source === "string") sources.add(entry.source);
+		const source = packageEntrySource(entry);
+		if (source) sources.add(source);
 	}
 	return { sources, path: current.path, exists: true };
+}
+
+function loadFirstPackageSources() {
+	return LOAD_FIRST_PACKAGE_IDS
+		.map((id) => PACKAGES.find((pkg) => pkg.id === id)?.source)
+		.filter(Boolean);
+}
+
+export function normalizePackageLoadOrderInSettings(settings) {
+	if (!Array.isArray(settings.packages)) return false;
+	const loadFirstSources = loadFirstPackageSources();
+	const priorityEntries = [];
+	const remainingEntries = [];
+
+	for (const [originalIndex, entry] of settings.packages.entries()) {
+		const source = packageEntrySource(entry);
+		const priorityIndex = source ? loadFirstSources.indexOf(source) : -1;
+		if (priorityIndex === -1) remainingEntries.push(entry);
+		else priorityEntries.push({ entry, priorityIndex, originalIndex });
+	}
+
+	if (priorityEntries.length === 0) return false;
+	priorityEntries.sort((a, b) => a.priorityIndex - b.priorityIndex || a.originalIndex - b.originalIndex);
+	const ordered = [...priorityEntries.map(({ entry }) => entry), ...remainingEntries];
+	const changed = ordered.some((entry, index) => entry !== settings.packages[index]);
+	if (changed) settings.packages = ordered;
+	return changed;
+}
+
+function normalizePackageLoadOrder(local) {
+	return writeSettings(local, normalizePackageLoadOrderInSettings);
+}
+
+function packageLoadOrderStatusFromSettings(settings) {
+	if (!Array.isArray(settings?.packages)) return { checked: false };
+	const sources = settings.packages.map(packageEntrySource);
+	const extensionSettings = PACKAGES.find((pkg) => pkg.id === "extension-settings")?.source;
+	const powerbar = PACKAGES.find((pkg) => pkg.id === "powerbar")?.source;
+	const extensionSettingsIndex = sources.indexOf(extensionSettings);
+	const powerbarIndex = sources.indexOf(powerbar);
+	if (extensionSettingsIndex === -1 || powerbarIndex === -1) return { checked: false };
+	return { checked: true, ok: extensionSettingsIndex < powerbarIndex, extensionSettingsIndex, powerbarIndex };
+}
+
+function packageLoadOrderStatus(local) {
+	const current = readSettings(local);
+	if (!current.exists) return { checked: false, path: current.path, exists: false };
+	if (current.error) return { checked: false, path: current.path, exists: true, error: current.error };
+	return { ...packageLoadOrderStatusFromSettings(current.parsed), path: current.path, exists: true };
+}
+
+function reportLoadOrderNormalization(result, interactive) {
+	if (!result.ok) {
+		const message = `Could not update package load order in ${result.path} — ${result.error}`;
+		if (interactive) log.warn(message);
+		else console.warn(yellow(message));
+		return;
+	}
+	if (!result.changed) return;
+	const backup = result.backup ? ` Backup: ${result.backup}` : "";
+	const message = `Updated package load order in ${result.path}: extension-settings loads first.${backup}`;
+	if (interactive) log.success(message);
+	else console.log(green(message));
 }
 
 function compoundInstallRoot(local) {
@@ -902,6 +972,9 @@ async function cmdInstall(flags) {
 		}
 	}
 
+	const preInstallLoadOrder = normalizePackageLoadOrder(flags.local);
+	reportLoadOrderNormalization(preInstallLoadOrder, interactive);
+
 	if (toInstall.length === 0) {
 		printCheatsheet(selected, interactive);
 		const done = "Nothing to do — every selected package is already installed.";
@@ -962,6 +1035,9 @@ async function cmdInstall(flags) {
 			else console.error(red(`  ✗ failed to install ${pkg.id}`));
 		}
 	}
+
+	const postInstallLoadOrder = normalizePackageLoadOrder(flags.local);
+	reportLoadOrderNormalization(postInstallLoadOrder, interactive);
 
 	const installedCount = toInstall.length - failed.length - skipped.length;
 	if (failed.length === 0) {
@@ -1100,6 +1176,8 @@ async function cmdUpdate(flags) {
 		return 1;
 	}
 
+	reportLoadOrderNormalization(normalizePackageLoadOrder(flags.local), false);
+
 	if (updateSelection.ids.includes(COMPOUND_PKG_ID)) {
 		console.log(bold("Step 1/2: refresh Compound Engineering"));
 		const installCode = await cmdInstall({
@@ -1165,7 +1243,12 @@ function cmdDoctor(flags) {
 	const { sources, path, exists, error } = readInstalledSources(flags.local);
 	if (!exists) warn(`${path} does not exist yet (Pi has not been run)`);
 	else if (error) fail(`${path} is not valid JSON — ${error}`);
-	else pass(`${path} is readable`);
+	else {
+		pass(`${path} is readable`);
+		const loadOrder = packageLoadOrderStatus(flags.local);
+		if (loadOrder.checked && loadOrder.ok) pass("pi-extension-settings loads before pi-powerbar");
+		else if (loadOrder.checked) warn(`pi-extension-settings loads after pi-powerbar — run ${bold("npx @robzolkos/lazypi --yes")} to repair package load order`);
+	}
 
 	printHeader("Catalog package health");
 	const compound = compoundInstallState(flags.local);

--- a/test/load-order.test.mjs
+++ b/test/load-order.test.mjs
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { normalizePackageLoadOrderInSettings, PACKAGES } from "../bin/lazypi.mjs";
+
+const CLI_PATH = resolve("bin/lazypi.mjs");
+const EXTENSION_SETTINGS_SOURCE = "npm:@juanibiapina/pi-extension-settings";
+const POWERBAR_SOURCE = "npm:@juanibiapina/pi-powerbar";
+const AUTH_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"TOGETHER_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+];
+
+function createWorkspace() {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-load-order-"));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+	const bin = join(root, "bin");
+	mkdirSync(join(workspace, ".pi"), { recursive: true });
+	mkdirSync(home, { recursive: true });
+	mkdirSync(bin, { recursive: true });
+	return { root, home, workspace, bin };
+}
+
+function writeFakePi(bin, callsPath) {
+	const piPath = join(bin, "pi");
+	writeFileSync(piPath, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${callsPath}"\nexit 0\n`);
+	chmodSync(piPath, 0o755);
+}
+
+function runCli(args, { cwd, home, bin } = {}) {
+	const env = {
+		...process.env,
+		HOME: home,
+		PATH: [bin, "/usr/bin", "/bin"].join(delimiter),
+	};
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		cwd,
+		env,
+		encoding: "utf8",
+		timeout: 60_000,
+	});
+	if (result.error) throw result.error;
+	return result;
+}
+
+function packageSources(settings) {
+	return settings.packages.map((entry) => typeof entry === "string" ? entry : entry.source);
+}
+
+test("catalog installs extension-settings before powerbar", () => {
+	const extensionSettingsIndex = PACKAGES.findIndex((pkg) => pkg.id === "extension-settings");
+	const powerbarIndex = PACKAGES.findIndex((pkg) => pkg.id === "powerbar");
+
+	assert.notEqual(extensionSettingsIndex, -1);
+	assert.notEqual(powerbarIndex, -1);
+	assert.ok(extensionSettingsIndex < powerbarIndex);
+});
+
+test("normalizePackageLoadOrderInSettings moves extension-settings to the front", () => {
+	const powerbarEntry = { source: POWERBAR_SOURCE, enabled: true };
+	const settings = {
+		packages: [
+			"npm:pi-subagents",
+			powerbarEntry,
+			EXTENSION_SETTINGS_SOURCE,
+			"npm:@tmustier/pi-usage-extension",
+		],
+	};
+
+	assert.equal(normalizePackageLoadOrderInSettings(settings), true);
+	assert.deepEqual(packageSources(settings), [
+		EXTENSION_SETTINGS_SOURCE,
+		"npm:pi-subagents",
+		POWERBAR_SOURCE,
+		"npm:@tmustier/pi-usage-extension",
+	]);
+	assert.equal(settings.packages[2], powerbarEntry);
+	assert.equal(normalizePackageLoadOrderInSettings(settings), false);
+});
+
+test("install repairs load order for already-installed local packages", () => {
+	const { root, home, workspace, bin } = createWorkspace();
+	const callsPath = join(root, "pi-calls.log");
+	writeFakePi(bin, callsPath);
+	const settingsPath = join(workspace, ".pi", "settings.json");
+	writeFileSync(settingsPath, JSON.stringify({ packages: [POWERBAR_SOURCE, EXTENSION_SETTINGS_SOURCE] }, null, 2) + "\n");
+
+	const result = runCli(["--yes", "--only", "extension-settings,powerbar", "-l"], { cwd: workspace, home, bin });
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.match(result.stdout, /Updated package load order/);
+
+	const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.deepEqual(settings.packages, [EXTENSION_SETTINGS_SOURCE, POWERBAR_SOURCE]);
+	assert.equal(readdirSync(join(workspace, ".pi")).some((name) => name.endsWith(".bak")), true);
+});
+
+test("update repairs load order before delegating to pi update", () => {
+	const { root, home, workspace, bin } = createWorkspace();
+	const callsPath = join(root, "pi-calls.log");
+	writeFakePi(bin, callsPath);
+	const settingsPath = join(workspace, ".pi", "settings.json");
+	writeFileSync(settingsPath, JSON.stringify({ packages: [POWERBAR_SOURCE, EXTENSION_SETTINGS_SOURCE] }, null, 2) + "\n");
+
+	const result = runCli(["update", "-l"], { cwd: workspace, home, bin });
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.match(result.stdout, /Updated package load order/);
+
+	const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.deepEqual(settings.packages, [EXTENSION_SETTINGS_SOURCE, POWERBAR_SOURCE]);
+	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+	assert.deepEqual(calls, ["update --extensions"]);
+});


### PR DESCRIPTION
## Summary
- Load `pi-extension-settings` before `pi-powerbar` for new LazyPi installs.
- Repair existing `settings.json` package order during `lazypi install` and `lazypi update`, with a backup before writing.
- Add a `doctor` load-order check and tests for the catalog order, repair helper, install repair, and update repair.

Closes #68.

## Tests
- `npm test`
