### PR TITLE
fix: honor PI_CODING_AGENT_DIR

### DIFF
--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -278,8 +278,18 @@ function hasCmd(name) {
 	return probe.status === 0;
 }
 
+function agentConfigDir() {
+	const configured = process.env.PI_CODING_AGENT_DIR;
+	if (!configured) return join(homedir(), ".pi", "agent");
+	if (configured === "~") return homedir();
+	if (configured.startsWith("~/") || (platform() === "win32" && configured.startsWith("~\\"))) {
+		return join(homedir(), configured.slice(2));
+	}
+	return configured;
+}
+
 function settingsPath(local) {
-	return local ? join(cwd(), ".pi", "settings.json") : join(homedir(), ".pi", "agent", "settings.json");
+	return local ? join(cwd(), ".pi", "settings.json") : join(agentConfigDir(), "settings.json");
 }
 
 // Builtin pi-subagents agents that hardcode a specific model — blank them out
@@ -409,7 +419,7 @@ function reportLoadOrderNormalization(result, interactive) {
 }
 
 function compoundInstallRoot(local) {
-	return local ? join(cwd(), ".pi") : join(homedir(), ".pi", "agent");
+	return local ? join(cwd(), ".pi") : agentConfigDir();
 }
 
 function readJsonFileWithMetadata(path) {
@@ -772,9 +782,9 @@ function readJsonSafe(path) {
 // ---------------------------------------------------------------------------
 // Auth detection (read-only)
 // ---------------------------------------------------------------------------
-// Pi reads credentials from ~/.pi/agent/auth.json and also honors provider
-// env vars. LazyPi never writes credentials itself — we just report what's
-// there so the user knows whether to run `pi /login` first.
+// Pi reads credentials from auth.json in its agent config directory and also
+// honors provider env vars. LazyPi reports the available credentials so users
+// know whether to run `pi /login` first.
 const AUTH_ENV_VARS = [
 	["ANTHROPIC_API_KEY", "anthropic"],
 	["OPENAI_API_KEY", "openai"],
@@ -787,7 +797,7 @@ const AUTH_ENV_VARS = [
 ];
 
 function authJsonPath() {
-	return join(homedir(), ".pi", "agent", "auth.json");
+	return join(agentConfigDir(), "auth.json");
 }
 
 function detectAuth() {
@@ -945,7 +955,7 @@ async function cmdInstall(flags) {
 		return !isPackageInstalled(pkg, installedSources, flags.local) && isPackagePresent(pkg, installedSources, flags.local);
 	});
 	const installLabel = legacyInstalled.length > 0 ? `${toInstall.length} (${legacyInstalled.length} migration${legacyInstalled.length === 1 ? "" : "s"})` : String(toInstall.length);
-	const scope = flags.local ? "project (.pi/settings.json)" : "global (~/.pi/agent/settings.json)";
+	const scope = flags.local ? "project (.pi/settings.json)" : `global (${settingsPath(false)})`;
 
 	const preInstallAuth = detectAuth();
 	const summary = [

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join, posix, resolve, win32 } from "node:path";
 import { spawnSync } from "node:child_process";
 import { argv, cwd, exit, stdout, stderr } from "node:process";
 import { pathToFileURL } from "node:url";
@@ -278,14 +278,18 @@ function hasCmd(name) {
 	return probe.status === 0;
 }
 
-function agentConfigDir() {
-	const configured = process.env.PI_CODING_AGENT_DIR;
-	if (!configured) return join(homedir(), ".pi", "agent");
-	if (configured === "~") return homedir();
-	if (configured.startsWith("~/") || (platform() === "win32" && configured.startsWith("~\\"))) {
-		return join(homedir(), configured.slice(2));
+export function resolveAgentConfigDir(configured, home = homedir(), platformName = platform()) {
+	const joinPath = platformName === "win32" ? win32.join : posix.join;
+	if (!configured) return joinPath(home, ".pi", "agent");
+	if (configured === "~") return home;
+	if (configured.startsWith("~/") || (platformName === "win32" && configured.startsWith("~\\"))) {
+		return joinPath(home, configured.slice(2));
 	}
 	return configured;
+}
+
+function agentConfigDir() {
+	return resolveAgentConfigDir(process.env.PI_CODING_AGENT_DIR);
 }
 
 function settingsPath(local) {

--- a/test/agent-dir.test.mjs
+++ b/test/agent-dir.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const CLI_PATH = resolve("bin/lazypi.mjs");
+
+function writeSettings(path, packages) {
+	mkdirSync(path, { recursive: true });
+	writeFileSync(join(path, "settings.json"), JSON.stringify({ packages }, null, 2) + "\n");
+}
+
+test("status honors PI_CODING_AGENT_DIR", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-agent-dir-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const home = join(root, "home");
+	const customAgentDir = join(home, ".pi", "lazy");
+	writeSettings(join(home, ".pi", "agent"), ["npm:pi-mcp-adapter"]);
+	writeSettings(customAgentDir, ["npm:pi-subagents"]);
+	mkdirSync(join(customAgentDir, "compound-engineering"), { recursive: true });
+	writeFileSync(join(customAgentDir, "compound-engineering", "install-manifest.json"), JSON.stringify({ files: ["AGENTS.md"] }, null, 2) + "\n");
+
+	const result = spawnSync(process.execPath, [CLI_PATH, "status"], {
+		env: {
+			...process.env,
+			HOME: home,
+			PI_CODING_AGENT_DIR: "~/.pi/lazy",
+		},
+		encoding: "utf8",
+	});
+
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.match(result.stdout, new RegExp(`Settings file: ${customAgentDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/settings\\.json`));
+	assert.match(result.stdout, /✓ \[core\] subagents/);
+	assert.match(result.stdout, /✓ \[frameworks\] compound/);
+	assert.doesNotMatch(result.stdout, /✓ \[core\] mcp/);
+});

--- a/test/agent-dir.test.mjs
+++ b/test/agent-dir.test.mjs
@@ -1,39 +1,164 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, dirname, join, posix, resolve, win32 } from "node:path";
 import { spawnSync } from "node:child_process";
 
+import { resolveAgentConfigDir } from "../bin/lazypi.mjs";
+
 const CLI_PATH = resolve("bin/lazypi.mjs");
+const EXTENSION_SETTINGS_SOURCE = "npm:@juanibiapina/pi-extension-settings";
+const POWERBAR_SOURCE = "npm:@juanibiapina/pi-powerbar";
+const AUTH_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"TOGETHER_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+];
+
+function createWorkspace(t) {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-agent-dir-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+	const bin = join(root, "bin");
+	mkdirSync(home, { recursive: true });
+	mkdirSync(workspace, { recursive: true });
+	mkdirSync(bin, { recursive: true });
+	return { root, home, workspace, bin };
+}
 
 function writeSettings(path, packages) {
 	mkdirSync(path, { recursive: true });
 	writeFileSync(join(path, "settings.json"), JSON.stringify({ packages }, null, 2) + "\n");
 }
 
-test("status honors PI_CODING_AGENT_DIR", (t) => {
-	const root = mkdtempSync(join(tmpdir(), "lazypi-agent-dir-"));
-	t.after(() => rmSync(root, { recursive: true, force: true }));
-	const home = join(root, "home");
+function writeJson(path, value) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(value, null, 2) + "\n");
+}
+
+function writeFakePi(bin) {
+	if (process.platform === "win32") {
+		writeFileSync(join(bin, "pi.cmd"), "@echo off\r\nif \"%1\"==\"--version\" echo pi test\r\nif defined PI_TEST_CALLS echo %*>>\"%PI_TEST_CALLS%\"\r\nexit /b 0\r\n");
+		return;
+	}
+	const piPath = join(bin, "pi");
+	writeFileSync(piPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'pi test'; fi\nif [ -n \"$PI_TEST_CALLS\" ]; then printf '%s\\n' \"$*\" >> \"$PI_TEST_CALLS\"; fi\nexit 0\n");
+	chmodSync(piPath, 0o755);
+}
+
+function runCli(args, { cwd, home, agentDir, bin, callsPath } = {}) {
+	const env = {
+		...process.env,
+		HOME: home,
+		USERPROFILE: home,
+		PI_CODING_AGENT_DIR: agentDir,
+	};
+	if (bin) env.PATH = [bin, process.env.PATH].filter(Boolean).join(delimiter);
+	if (callsPath) env.PI_TEST_CALLS = callsPath;
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		cwd,
+		env,
+		encoding: "utf8",
+		timeout: 60_000,
+	});
+	if (result.error) throw result.error;
+	return result;
+}
+
+test("resolveAgentConfigDir matches Pi path semantics", () => {
+	const posixHome = "/home/tester";
+	const windowsHome = "C:\\Users\\tester";
+	const cases = [
+		["unset", undefined, posixHome, "linux", posix.join(posixHome, ".pi", "agent")],
+		["empty", "", posixHome, "linux", posix.join(posixHome, ".pi", "agent")],
+		["absolute", "/opt/pi-agent", posixHome, "linux", "/opt/pi-agent"],
+		["relative", ".config/pi-agent", posixHome, "linux", ".config/pi-agent"],
+		["home", "~", posixHome, "linux", posixHome],
+		["home child", "~/.pi/lazy", posixHome, "linux", posix.join(posixHome, ".pi", "lazy")],
+		["Windows home child", "~\\.pi\\lazy", windowsHome, "win32", win32.join(windowsHome, ".pi", "lazy")],
+		["Windows default", undefined, windowsHome, "win32", win32.join(windowsHome, ".pi", "agent")],
+	];
+
+	for (const [name, configured, home, platformName, expected] of cases) {
+		assert.equal(resolveAgentConfigDir(configured, home, platformName), expected, name);
+	}
+});
+
+test("status reads settings and Compound state from PI_CODING_AGENT_DIR", (t) => {
+	const { home, workspace } = createWorkspace(t);
 	const customAgentDir = join(home, ".pi", "lazy");
 	writeSettings(join(home, ".pi", "agent"), ["npm:pi-mcp-adapter"]);
 	writeSettings(customAgentDir, ["npm:pi-subagents"]);
-	mkdirSync(join(customAgentDir, "compound-engineering"), { recursive: true });
-	writeFileSync(join(customAgentDir, "compound-engineering", "install-manifest.json"), JSON.stringify({ files: ["AGENTS.md"] }, null, 2) + "\n");
+	writeJson(join(customAgentDir, "compound-engineering", "install-manifest.json"), { files: ["AGENTS.md"] });
 
-	const result = spawnSync(process.execPath, [CLI_PATH, "status"], {
-		env: {
-			...process.env,
-			HOME: home,
-			PI_CODING_AGENT_DIR: "~/.pi/lazy",
-		},
-		encoding: "utf8",
-	});
+	const result = runCli(["status"], { cwd: workspace, home, agentDir: "~/.pi/lazy" });
 
 	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
-	assert.match(result.stdout, new RegExp(`Settings file: ${customAgentDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/settings\\.json`));
+	assert.ok(result.stdout.includes(`Settings file: ${join(customAgentDir, "settings.json")}`));
 	assert.match(result.stdout, /✓ \[core\] subagents/);
 	assert.match(result.stdout, /✓ \[frameworks\] compound/);
 	assert.doesNotMatch(result.stdout, /✓ \[core\] mcp/);
+});
+
+test("install reads auth and writes settings in PI_CODING_AGENT_DIR", (t) => {
+	const { home, workspace, bin } = createWorkspace(t);
+	const defaultAgentDir = join(home, ".pi", "agent");
+	const customAgentDir = join(home, ".pi", "lazy");
+	writeFakePi(bin);
+	writeSettings(defaultAgentDir, ["npm:pi-mcp-adapter"]);
+	writeSettings(customAgentDir, ["npm:pi-subagents"]);
+	writeJson(join(defaultAgentDir, "auth.json"), { openai: { type: "api_key", key: "default" } });
+	writeJson(join(customAgentDir, "auth.json"), { anthropic: { type: "api_key", key: "custom" } });
+
+	const result = runCli(["--yes", "--only", "subagents"], { cwd: workspace, home, agentDir: customAgentDir, bin });
+
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.match(result.stdout, /Pi credentials:\s+anthropic \(auth\.json\)/);
+	const customSettings = JSON.parse(readFileSync(join(customAgentDir, "settings.json"), "utf8"));
+	const defaultSettings = JSON.parse(readFileSync(join(defaultAgentDir, "settings.json"), "utf8"));
+	assert.equal(customSettings.subagents.agentOverrides.reviewer.model, "");
+	assert.equal(defaultSettings.subagents, undefined);
+});
+
+test("update and remove inspect the custom global settings", (t) => {
+	const { root, home, workspace, bin } = createWorkspace(t);
+	const callsPath = join(root, "pi-calls.log");
+	const defaultAgentDir = join(home, ".pi", "agent");
+	const customAgentDir = join(home, ".pi", "lazy");
+	writeFakePi(bin);
+	writeSettings(defaultAgentDir, ["npm:pi-subagents"]);
+	writeSettings(customAgentDir, [POWERBAR_SOURCE, EXTENSION_SETTINGS_SOURCE, "npm:pi-memory-md"]);
+
+	const updateResult = runCli(["update"], { cwd: workspace, home, agentDir: customAgentDir, bin, callsPath });
+	assert.equal(updateResult.status, 0, `STDOUT:\n${updateResult.stdout}\nSTDERR:\n${updateResult.stderr}`);
+	const customSettings = JSON.parse(readFileSync(join(customAgentDir, "settings.json"), "utf8"));
+	assert.deepEqual(customSettings.packages, [EXTENSION_SETTINGS_SOURCE, POWERBAR_SOURCE, "npm:pi-memory-md"]);
+	assert.deepEqual(JSON.parse(readFileSync(join(defaultAgentDir, "settings.json"), "utf8")).packages, ["npm:pi-subagents"]);
+
+	const removeResult = runCli(["remove", "memory"], { cwd: workspace, home, agentDir: customAgentDir, bin, callsPath });
+	assert.equal(removeResult.status, 0, `STDOUT:\n${removeResult.stdout}\nSTDERR:\n${removeResult.stderr}`);
+	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+	assert.deepEqual(calls, ["update", "remove npm:pi-memory-md"]);
+});
+
+test("--local settings remain independent of PI_CODING_AGENT_DIR", (t) => {
+	const { home, workspace } = createWorkspace(t);
+	const customAgentDir = join(home, ".pi", "lazy");
+	writeSettings(customAgentDir, ["npm:pi-subagents"]);
+	writeSettings(join(workspace, ".pi"), ["npm:pi-mcp-adapter"]);
+
+	const result = runCli(["status", "--local"], { cwd: workspace, home, agentDir: customAgentDir });
+
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+	assert.ok(result.stdout.includes(`Settings file: ${join(workspace, ".pi", "settings.json")}`));
+	assert.match(result.stdout, /✓ \[core\] mcp/);
+	assert.doesNotMatch(result.stdout, /✓ \[core\] subagents/);
 });


### PR DESCRIPTION
## Summary

- resolve LazyPi's global settings, auth, and Compound Engineering paths from `PI_CODING_AGENT_DIR`
- preserve Pi-compatible defaults, tilde expansion, relative paths, Windows paths, and project-local behavior
- report the resolved global settings target during installation
- add cross-platform coverage for status, install/auth writes, update, remove, Compound state, and `--local` isolation

## Testing

- `node --test test/agent-dir.test.mjs`
- `LAZYPI_SKIP_COMPOUND_INTEGRATION=1 npm test` (25 passed, 3 external Compound integration tests skipped)
- independent Codex review: no actionable findings

Closes #73
