### PR TITLE
fix: safely migrate to the maintained Claude CLI provider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.19.0
           cache: npm
 
       - name: Install bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,12 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
+    env:
+      npm_config_cache: /tmp/lazypi-npm-cache
+      npm_config_audit: "false"
+      npm_config_fund: "false"
+      BUN_INSTALL_CACHE_DIR: /tmp/lazypi-bun-cache
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.19.0
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.19.0
 
       - name: Install pi
         run: npm install -g @earendil-works/pi-coding-agent

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The [Pi](https://github.com/earendil-works/pi-mono) coding agent is minimal by d
 
 ## Quick start
 
+LazyPi requires Node.js 22.19 or later.
+
 ```bash
 npx @robzolkos/lazypi
 ```
@@ -26,7 +28,7 @@ Install is **idempotent** — LazyPi reads your Pi settings and skips any packag
 | `npx @robzolkos/lazypi` | Install all or selected catalog (interactive picker by default) |
 | `npx @robzolkos/lazypi remove <id>` | Remove a catalog package by id (or pass a raw pi source) |
 | `npx @robzolkos/lazypi status` | Show which catalog packages are installed, missing, or extra |
-| `npx @robzolkos/lazypi update` | Run `pi update` for installed Pi packages |
+| `npx @robzolkos/lazypi update` | Migrate legacy catalog sources and update Pi plus installed packages |
 | `npx @robzolkos/lazypi doctor` | Check your environment for common problems |
 
 ## Updating
@@ -34,6 +36,8 @@ Install is **idempotent** — LazyPi reads your Pi settings and skips any packag
 ```bash
 npx @robzolkos/lazypi update
 ```
+
+Update migrates installed legacy catalog sources, refreshes Compound Engineering when present, and runs Pi's full updater. See the [updating guide](https://lazypi.org/docs/updating.html) for migration and failure behavior.
 
 ## Removing packages
 

--- a/bin/lazypi.mjs
+++ b/bin/lazypi.mjs
@@ -42,7 +42,14 @@ export const PACKAGES = [
 	{ id: "simplify", category: "core", source: "npm:pi-simplify", description: "Code simplify review", hint: "Reviews recently changed code for clarity, consistency, and maintainability." },
 	{ id: "add-dir", category: "core", source: "npm:pi-add-dir", description: "Add external directories", hint: "Load configs and skills from additional project directories in the same Pi session." },
 	{ id: "prompt-templates", category: "core", source: "npm:pi-prompt-template-model", description: "Prompt template model switching", hint: "Add model, skill, and thinking frontmatter so prompt templates switch modes automatically." },
-	{ id: "claude-cli", category: "core", source: "npm:pi-claude-cli", description: "Claude Code CLI provider", hint: "Use Claude Code CLI auth as a Pi model provider." },
+	{
+		id: "claude-cli",
+		category: "core",
+		source: "npm:@saccolabs/pi-claude-cli@0.6.1",
+		legacySources: ["npm:pi-claude-cli"],
+		description: "Claude Code CLI provider",
+		hint: "Use Claude Code CLI auth as a Pi model provider.",
+	},
 	{ id: "plannotator", category: "ui", source: "npm:@plannotator/pi-extension", description: "Planning and annotation workflow", hint: "Plan + annotate large changes interactively." },
 	{ id: "slopchop", category: "ui", source: "npm:pi-slopchop", description: "Diff review and annotation", hint: "Review diffs inside Pi and turn FIX/DISCUSS annotations into the next prompt." },
 	{ id: "extension-settings", category: "ui", source: "npm:@juanibiapina/pi-extension-settings", description: "Settings support for powerbar", hint: "Required by powerbar for its settings panel." },
@@ -69,6 +76,7 @@ export const PACKAGES = [
 
 const PI_CORE_PACKAGE = "@earendil-works/pi-coding-agent";
 const PI_CORE_LATEST_SPEC = `${PI_CORE_PACKAGE}@latest`;
+export const MIN_NODE_VERSION = "22.19.0";
 const COMPOUND_PKG_ID = "compound";
 const COMPOUND_SOURCE = "npm:@every-env/compound-plugin";
 const COMPOUND_UPSTREAM_PACKAGE = "@every-env/compound-plugin@3.0.0";
@@ -95,6 +103,39 @@ const white = c("1;97");
 
 function printHeader(text) {
 	console.log(`\n${bold(text)}`);
+}
+
+export function isSupportedNodeVersion(version, minimum = MIN_NODE_VERSION) {
+	const parseVersion = (value) => {
+		const match = String(value).trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/);
+		return match ? { core: match.slice(1, 4).map(Number), prerelease: match[4]?.split(".") ?? [] } : null;
+	};
+	const comparePrerelease = (left, right) => {
+		if (left.length === 0 || right.length === 0) return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
+		for (let index = 0; index < Math.max(left.length, right.length); index++) {
+			if (left[index] == null || right[index] == null) return left[index] == null ? -1 : 1;
+			const leftNumber = /^\d+$/.test(left[index]) ? Number(left[index]) : null;
+			const rightNumber = /^\d+$/.test(right[index]) ? Number(right[index]) : null;
+			if (leftNumber != null && rightNumber != null && leftNumber !== rightNumber) return leftNumber > rightNumber ? 1 : -1;
+			if (leftNumber != null && rightNumber == null) return -1;
+			if (leftNumber == null && rightNumber != null) return 1;
+			if (left[index] !== right[index]) return left[index] > right[index] ? 1 : -1;
+		}
+		return 0;
+	};
+	const actual = parseVersion(version);
+	const required = parseVersion(minimum);
+	if (!actual || !required) return false;
+	for (let index = 0; index < required.core.length; index++) {
+		if (actual.core[index] !== required.core[index]) return actual.core[index] > required.core[index];
+	}
+	return comparePrerelease(actual.prerelease, required.prerelease) >= 0;
+}
+
+function requireSupportedNode() {
+	if (isSupportedNodeVersion(process.versions.node)) return true;
+	console.error(red(`Node ${process.versions.node} is unsupported — LazyPi and current Pi require Node >= ${MIN_NODE_VERSION}`));
+	return false;
 }
 
 // ASCII "Pi" logo: capital P + lowercase i, with a blue "zzz" cascade
@@ -224,7 +265,7 @@ ${bold("Commands:")}
   install   Install the selected LazyPi catalog (default)
   remove    Remove a catalog package by id (or pass a raw pi source)
   status    Show which catalog packages are installed
-  update    Run \`pi update\` for installed Pi packages
+  update    Migrate catalog sources and update Pi plus installed packages
   doctor    Check your environment for common problems
 
 ${bold("Install options:")}
@@ -738,12 +779,121 @@ function legacySourcesForPackage(pkg) {
 	return Array.isArray(pkg.legacySources) ? pkg.legacySources : [];
 }
 
+function npmPackageName(source) {
+	if (typeof source !== "string" || !source.startsWith("npm:")) return null;
+	const spec = source.slice("npm:".length).trim();
+	const match = spec.match(/^(@?[^@]+(?:\/[^@]+)?)(?:@(.+))?$/);
+	return match?.[1] ?? null;
+}
+
+function npmPackageVersion(source) {
+	if (typeof source !== "string" || !source.startsWith("npm:")) return null;
+	const spec = source.slice("npm:".length).trim();
+	const match = spec.match(/^(@?[^@]+(?:\/[^@]+)?)(?:@(.+))?$/);
+	return match?.[2] ?? null;
+}
+
+function gitRepositorySource(source) {
+	if (typeof source !== "string" || !source.startsWith("git:")) return null;
+	const repository = source.slice("git:".length);
+	const refIndex = repository.lastIndexOf("@");
+	return refIndex > repository.lastIndexOf("/") ? repository.slice(0, refIndex) : repository;
+}
+
+function packageSourceIdentity(source) {
+	const npmName = npmPackageName(source);
+	if (npmName) return `npm:${npmName}`;
+	const gitRepository = gitRepositorySource(source);
+	if (gitRepository) return `git:${gitRepository}`;
+	return source;
+}
+
+function sourcesSharePackageIdentity(left, right) {
+	return packageSourceIdentity(left) === packageSourceIdentity(right);
+}
+
+function dedupeSourcesByPackageIdentity(sources) {
+	const seen = new Set();
+	return sources.filter((source) => {
+		const identity = packageSourceIdentity(source);
+		if (seen.has(identity)) return false;
+		seen.add(identity);
+		return true;
+	});
+}
+
 function isLegacySourceForPackage(pkg, source) {
-	return legacySourcesForPackage(pkg).includes(source);
+	return legacySourcesForPackage(pkg).some((legacySource) => {
+		if (source === legacySource) return true;
+		const sourceName = npmPackageName(source);
+		const legacyName = npmPackageName(legacySource);
+		if (!sourceName || !legacyName || sourceName !== legacyName) return false;
+		return legacyName !== npmPackageName(pkg.source);
+	});
 }
 
 function findLegacyInstalledSources(pkg, installedPiSources) {
 	return [...installedPiSources].filter((source) => isLegacySourceForPackage(pkg, source));
+}
+
+function isCurrentSourceVariant(pkg, source) {
+	if (source === pkg.source) return true;
+	if (isLegacySourceForPackage(pkg, source)) return false;
+	const sourceName = npmPackageName(source);
+	return sourceName != null && sourceName === npmPackageName(pkg.source);
+}
+
+function findCurrentInstalledSourceVariants(pkg, installedPiSources) {
+	if (!npmPackageVersion(pkg.source)) return [];
+	return [...installedPiSources].filter((source) => source !== pkg.source && isCurrentSourceVariant(pkg, source));
+}
+
+function findSourcesRequiringMigration(pkg, installedPiSources) {
+	return [...new Set([
+		...findLegacyInstalledSources(pkg, installedPiSources),
+		...findCurrentInstalledSourceVariants(pkg, installedPiSources),
+	])];
+}
+
+function findPackageEntry(local, predicate) {
+	const current = readSettings(local);
+	if (current.error) return { entry: null, error: current.error };
+	const entries = (current.parsed?.packages ?? []).filter((candidate) => {
+		const source = packageEntrySource(candidate);
+		return source != null && predicate(source);
+	});
+	const entry = entries.find((candidate) => typeof candidate === "object") ?? entries[0];
+	return { entry: entry ?? null, error: null };
+}
+
+function crossScopeMigrationConflict(pkg, installedPiSources, local) {
+	const identityChangingLegacySources = findLegacyInstalledSources(pkg, installedPiSources)
+		.filter((source) => !sourcesSharePackageIdentity(source, pkg.source));
+	if (identityChangingLegacySources.length === 0) return null;
+
+	const otherScope = readInstalledSources(!local);
+	const scopeLabel = local ? "global" : "project";
+	if (otherScope.error) {
+		return { error: `could not verify ${scopeLabel} settings (${otherScope.error}); fix that file before migrating`, scopeLabel, sources: [] };
+	}
+	const sources = [...otherScope.sources].filter((source) =>
+		identityChangingLegacySources.some((legacySource) => sourcesSharePackageIdentity(source, legacySource))
+	);
+	return sources.length > 0 ? { error: null, scopeLabel, sources } : null;
+}
+
+function crossScopeMigrationReason(conflict) {
+	return conflict.error
+		?? `${conflict.sources.join(", ")} is also configured in ${conflict.scopeLabel} settings; remove the duplicate from one scope before migrating`;
+}
+
+function findCrossScopeMigrationFailure(packages, installedPiSources, local) {
+	for (const pkg of packages) {
+		if (pkg.id === COMPOUND_PKG_ID) continue;
+		const conflict = crossScopeMigrationConflict(pkg, installedPiSources, local);
+		if (conflict) return { pkg, reason: crossScopeMigrationReason(conflict) };
+	}
+	return null;
 }
 
 function packageInstallStatus(pkg, installedPiSources, local) {
@@ -755,11 +905,11 @@ function packageInstallStatus(pkg, installedPiSources, local) {
 			present: mode === "manifest" || mode === "legacy",
 		};
 	}
-	const legacySources = findLegacyInstalledSources(pkg, installedPiSources);
+	const migrationSources = findSourcesRequiringMigration(pkg, installedPiSources);
 	return {
 		installed: installedPiSources.has(pkg.source),
-		legacy: legacySources.length > 0,
-		present: installedPiSources.has(pkg.source) || legacySources.length > 0,
+		legacy: migrationSources.length > 0,
+		present: installedPiSources.has(pkg.source) || migrationSources.length > 0,
 	};
 }
 
@@ -769,6 +919,165 @@ function isPackageInstalled(pkg, installedPiSources, local) {
 
 function isPackagePresent(pkg, installedPiSources, local) {
 	return packageInstallStatus(pkg, installedPiSources, local).present;
+}
+
+function reportPackageAction(action, interactive) {
+	if (interactive) log.step(action);
+	else console.log(`\n→ ${action}`);
+}
+
+let supportsPiApprovalFlag;
+let supportsPiUpdateAllFlag;
+
+function piSupportsApprovalFlag() {
+	if (supportsPiApprovalFlag != null) return supportsPiApprovalFlag;
+	const result = spawnCommand("pi", ["install", "--help"], { encoding: "utf8" });
+	const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+	supportsPiApprovalFlag = result.status === 0 && output.includes("--approve");
+	return supportsPiApprovalFlag;
+}
+
+function piSupportsUpdateAll() {
+	if (supportsPiUpdateAllFlag != null) return supportsPiUpdateAllFlag;
+	const result = spawnCommand("pi", ["update", "--help"], { encoding: "utf8" });
+	const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+	supportsPiUpdateAllFlag = result.status === 0 && output.includes("--all");
+	return supportsPiUpdateAllFlag;
+}
+
+function runPackageMutation(command, source, flags, interactive) {
+	const action = `pi ${command} ${source}`;
+	reportPackageAction(action, interactive);
+	const localArgs = flags.local
+		? [command, "-l", ...(piSupportsApprovalFlag() ? ["--approve"] : []), source]
+		: [command, source];
+	const env = command === "install" && source.startsWith("git:")
+		? { ...process.env, npm_config_ignore_scripts: "true" }
+		: process.env;
+	return spawnCommand("pi", localArgs, { stdio: "inherit", env }).status ?? 1;
+}
+
+function preserveReplacementPackageEntry(pkg, local, legacyEntry) {
+	if (!legacyEntry) return { ok: true, changed: false };
+	let found = false;
+	try {
+		const result = writeSettings(local, (settings) => {
+			if (!Array.isArray(settings.packages)) return false;
+			const legacyIndex = settings.packages.findIndex((entry) => {
+				const source = packageEntrySource(entry);
+				return source != null
+					&& isLegacySourceForPackage(pkg, source)
+					&& (typeof legacyEntry !== "object" || typeof entry === "object");
+			});
+			const replacementIndex = settings.packages.findIndex((entry) => packageEntrySource(entry) === pkg.source);
+			if (legacyIndex === -1 || replacementIndex === -1) return false;
+			found = true;
+			const existingReplacement = settings.packages[replacementIndex];
+			if (typeof existingReplacement === "object" || typeof legacyEntry !== "object") return false;
+			const replacementEntry = { ...legacyEntry, source: pkg.source };
+			const nextPackages = [...settings.packages];
+			nextPackages.splice(replacementIndex, 1);
+			const adjustedLegacyIndex = replacementIndex < legacyIndex ? legacyIndex - 1 : legacyIndex;
+			nextPackages.splice(adjustedLegacyIndex + 1, 0, replacementEntry);
+			settings.packages = nextPackages;
+			return true;
+		});
+		if (!result.ok || !found) {
+			return { ok: false, error: result.error ?? `replacement source ${pkg.source} is missing from settings` };
+		}
+		return result;
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function consolidateSameIdentityPackageEntries(pkg, local) {
+	try {
+		return writeSettings(local, (settings) => {
+			if (!Array.isArray(settings.packages)) return false;
+			const matchingIndexes = settings.packages
+				.map((entry, index) => sourcesSharePackageIdentity(packageEntrySource(entry), pkg.source) ? index : -1)
+				.filter((index) => index !== -1);
+			if (matchingIndexes.length < 2) return false;
+			const firstIndex = matchingIndexes[0];
+			const preferredIndex = matchingIndexes.find((index) => {
+				const entry = settings.packages[index];
+				return packageEntrySource(entry) === pkg.source && typeof entry === "object";
+			}) ?? matchingIndexes.find((index) => typeof settings.packages[index] === "object")
+				?? matchingIndexes.find((index) => packageEntrySource(settings.packages[index]) === pkg.source)
+				?? firstIndex;
+			const preferredEntry = settings.packages[preferredIndex];
+			const replacementEntry = typeof preferredEntry === "object"
+				? { ...preferredEntry, source: pkg.source }
+				: pkg.source;
+			const nextPackages = settings.packages.filter((_, index) => !matchingIndexes.includes(index));
+			nextPackages.splice(firstIndex, 0, replacementEntry);
+			settings.packages = nextPackages;
+			return true;
+		});
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function migrateOrInstallPackage(pkg, installedPiSources, flags, interactive) {
+	const initialMigrationSources = findSourcesRequiringMigration(pkg, installedPiSources);
+	const scopeConflict = crossScopeMigrationConflict(pkg, installedPiSources, flags.local);
+	if (scopeConflict) {
+		return { ok: false, phase: "cross-scope", reason: crossScopeMigrationReason(scopeConflict), rollbackFailures: [] };
+	}
+
+	const replacementWasInstalled = [...installedPiSources].some((source) => isCurrentSourceVariant(pkg, source));
+	const legacyEntryResult = findPackageEntry(flags.local, (source) => isLegacySourceForPackage(pkg, source));
+	const legacyEntry = legacyEntryResult.entry;
+
+	if (!installedPiSources.has(pkg.source)) {
+		const installStatus = runPackageMutation("install", pkg.source, flags, interactive);
+		if (installStatus !== 0) return { ok: false, phase: "install", rollbackFailures: [] };
+	}
+
+	const postInstallState = readInstalledSources(flags.local);
+	if (postInstallState.error) {
+		return { ok: false, phase: "verify-install", rollbackFailures: [] };
+	}
+	const legacySources = findLegacyInstalledSources(pkg, postInstallState.sources);
+
+	if (legacySources.length > 0 && legacyEntry) {
+		const preserveResult = preserveReplacementPackageEntry(pkg, flags.local, legacyEntry);
+		if (!preserveResult.ok) {
+			const rollbackFailures = [];
+			if (runPackageMutation("remove", pkg.source, flags, interactive) !== 0) rollbackFailures.push(pkg.source);
+			return { ok: false, phase: "preserve-config", rollbackFailures };
+		}
+	}
+
+	const sameIdentitySources = postInstallState.sources.has(pkg.source)
+		? [...postInstallState.sources].filter((source) => source !== pkg.source && sourcesSharePackageIdentity(source, pkg.source))
+		: [];
+	if (sameIdentitySources.length > 0) {
+		const cleanupResult = consolidateSameIdentityPackageEntries(pkg, flags.local);
+		if (!cleanupResult.ok) return { ok: false, phase: "remove-legacy", rollbackFailures: [] };
+	}
+	const removableLegacySources = dedupeSourcesByPackageIdentity(
+		legacySources.filter((source) => !sameIdentitySources.includes(source)),
+	);
+
+	const removedLegacySources = [];
+	for (const legacySource of removableLegacySources) {
+		const removeStatus = runPackageMutation("remove", legacySource, flags, interactive);
+		if (removeStatus === 0) {
+			removedLegacySources.push(legacySource);
+			continue;
+		}
+
+		const rollbackFailures = [];
+		for (const removedSource of removedLegacySources.reverse()) {
+			if (runPackageMutation("install", removedSource, flags, interactive) !== 0) rollbackFailures.push(removedSource);
+		}
+		return { ok: false, phase: "remove-legacy", rollbackFailures };
+	}
+
+	return { ok: true, migrated: initialMigrationSources.length > 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -914,6 +1223,7 @@ async function ensurePi(flags) {
 // install
 // ---------------------------------------------------------------------------
 async function cmdInstall(flags) {
+	if (!requireSupportedNode()) return 1;
 	let selectedIds = expandPackageDependencies(resolveSelection(flags));
 
 	const usedSelectionFlag = Boolean(flags.only || flags.except);
@@ -923,7 +1233,6 @@ async function cmdInstall(flags) {
 		console.log(renderLogo());
 		intro(bold("LazyPi"));
 	}
-	if (!(await ensurePi(flags))) return 127;
 
 	if (interactive) {
 		const choice = await askLazyOrPick(PACKAGES.length);
@@ -946,17 +1255,20 @@ async function cmdInstall(flags) {
 	const toInstall = selected.filter((pkg) => {
 		if (forceIds.has(pkg.id)) return true;
 		if (pkg.id === COMPOUND_PKG_ID) return !isCompoundInstalled(flags.local) || compoundNeedsMigration(flags.local);
-		return !isPackageInstalled(pkg, installedSources, flags.local);
+		const status = packageInstallStatus(pkg, installedSources, flags.local);
+		return !status.installed || status.legacy;
 	});
 	const alreadyInstalled = selected.filter((pkg) => {
 		if (forceIds.has(pkg.id)) return false;
 		if (pkg.id === COMPOUND_PKG_ID) return isCompoundInstalled(flags.local) && !compoundNeedsMigration(flags.local);
-		return isPackageInstalled(pkg, installedSources, flags.local);
+		const status = packageInstallStatus(pkg, installedSources, flags.local);
+		return status.installed && !status.legacy;
 	});
 	const legacyInstalled = selected.filter((pkg) => {
 		if (forceIds.has(pkg.id)) return false;
-		if (pkg.id === COMPOUND_PKG_ID) return compoundNeedsMigration(flags.local);
-		return !isPackageInstalled(pkg, installedSources, flags.local) && isPackagePresent(pkg, installedSources, flags.local);
+		return pkg.id === COMPOUND_PKG_ID
+			? compoundNeedsMigration(flags.local)
+			: packageInstallStatus(pkg, installedSources, flags.local).legacy;
 	});
 	const installLabel = legacyInstalled.length > 0 ? `${toInstall.length} (${legacyInstalled.length} migration${legacyInstalled.length === 1 ? "" : "s"})` : String(toInstall.length);
 	const scope = flags.local ? "project (.pi/settings.json)" : `global (${settingsPath(false)})`;
@@ -971,6 +1283,20 @@ async function cmdInstall(flags) {
 	].join("\n");
 	if (interactive) note(summary, "Plan");
 	else console.log(summary);
+
+	const migrationFailure = findCrossScopeMigrationFailure(toInstall, installedSources, flags.local);
+	if (migrationFailure) {
+		const message = `Refusing to migrate ${migrationFailure.pkg.id}: ${migrationFailure.reason}`;
+		if (interactive) {
+			log.error(message);
+			outro(red("Aborted."));
+		} else {
+			console.error(red(message));
+		}
+		return 1;
+	}
+
+	if (!(await ensurePi(flags))) return 127;
 
 	if (selected.some((p) => p.id === "subagents")) {
 		const overrideResult = writeSubagentOverrides(flags.local);
@@ -999,7 +1325,6 @@ async function cmdInstall(flags) {
 		return 0;
 	}
 
-	const piArgs = flags.local ? ["install", "-l"] : ["install"];
 	const failed = [];
 	const skipped = [];
 
@@ -1020,33 +1345,16 @@ async function cmdInstall(flags) {
 			continue;
 		}
 
-		const legacySources = findLegacyInstalledSources(pkg, installedSources);
-		let migrationStatus = 0;
-		for (const legacySource of legacySources) {
-			const removeAction = `pi remove ${legacySource}`;
-			if (interactive) log.step(removeAction);
-			else console.log(`\n→ ${removeAction}`);
-			migrationStatus = spawnCommand("pi", flags.local ? ["remove", "-l", legacySource] : ["remove", legacySource], { stdio: "inherit" }).status ?? 1;
-			if (migrationStatus !== 0) break;
-		}
-		if (migrationStatus !== 0) {
+		const result = migrateOrInstallPackage(pkg, installedSources, flags, interactive);
+		if (!result.ok) {
 			failed.push(pkg);
-			if (interactive) log.error(`failed to migrate ${pkg.id}`);
-			else console.error(red(`  ✗ failed to migrate ${pkg.id}`));
-			continue;
-		}
-
-		const action = `pi install ${pkg.source}`;
-		if (interactive) log.step(action);
-		else console.log(`\n→ ${action}`);
-		const env = pkg.source.startsWith("git:")
-			? { ...process.env, npm_config_ignore_scripts: "true" }
-			: process.env;
-		const status = spawnCommand("pi", [...piArgs, pkg.source], { stdio: "inherit", env }).status;
-		if (status !== 0) {
-			failed.push(pkg);
-			if (interactive) log.error(`failed to install ${pkg.id}`);
-			else console.error(red(`  ✗ failed to install ${pkg.id}`));
+			const operation = result.phase === "install" ? "install" : "migrate";
+			const reason = result.reason ? ` (${result.reason})` : "";
+			const rollback = result.rollbackFailures.length > 0
+				? `; rollback also failed for ${result.rollbackFailures.join(", ")}`
+				: "";
+			if (interactive) log.error(`failed to ${operation} ${pkg.id}${reason}${rollback}`);
+			else console.error(red(`  ✗ failed to ${operation} ${pkg.id}${reason}${rollback}`));
 		}
 	}
 
@@ -1136,7 +1444,9 @@ function cmdStatus(flags) {
 	const installed = PACKAGES.filter((pkg) => packageInstallStatus(pkg, sources, flags.local).installed);
 	const legacy = PACKAGES.filter((pkg) => packageInstallStatus(pkg, sources, flags.local).legacy);
 	const missing = PACKAGES.filter((pkg) => !packageInstallStatus(pkg, sources, flags.local).present);
-	const others = [...sources].filter((src) => !piCatalogSources.has(src) && !PACKAGES.some((pkg) => isLegacySourceForPackage(pkg, src)));
+	const others = [...sources].filter((src) =>
+		!piCatalogSources.has(src) && !PACKAGES.some((pkg) => findSourcesRequiringMigration(pkg, new Set([src])).length > 0)
+	);
 
 	printHeader(`Installed from LazyPi catalog (${installed.length}/${PACKAGES.length}):`);
 	if (installed.length === 0) console.log(dim("  none"));
@@ -1148,9 +1458,9 @@ function cmdStatus(flags) {
 	if (legacy.length === 0) console.log(dim("  none"));
 	for (const pkg of legacy) {
 		const detail = pkg.id === COMPOUND_PKG_ID
-			? dim("legacy LazyPi state detected — run `lazypi update` to migrate to CE 3")
-			: findLegacyInstalledSources(pkg, sources).map((src) => dim(src)).join(", ");
-		console.log(`  ${yellow("!")} [${pkg.category}] ${pkg.id.padEnd(20)} ${detail}`);
+			? "legacy LazyPi state detected"
+			: findSourcesRequiringMigration(pkg, sources).join(", ");
+		console.log(`  ${yellow("!")} [${pkg.category}] ${pkg.id.padEnd(20)} ${dim(`${detail} — run \`lazypi update\` to migrate`)}`);
 	}
 
 	printHeader(`Missing from LazyPi catalog (${missing.length}):`);
@@ -1168,12 +1478,13 @@ function cmdStatus(flags) {
 
 function resolveUpdateCatalogIds(flags) {
 	const { sources, error } = readInstalledSources(flags.local);
-	if (error) return { ids: [], error };
+	if (error) return { ids: [], sources, error };
 	const selectedIds = resolveSelection(flags);
 	return {
 		ids: PACKAGES
 			.filter((pkg) => selectedIds.has(pkg.id) && isPackagePresent(pkg, sources, flags.local))
 			.map((pkg) => pkg.id),
+		sources,
 		error: null,
 	};
 }
@@ -1182,7 +1493,7 @@ function resolveUpdateCatalogIds(flags) {
 // update
 // ---------------------------------------------------------------------------
 async function cmdUpdate(flags) {
-	if (!(await ensurePi(flags))) return 127;
+	if (!requireSupportedNode()) return 1;
 
 	const updateSelection = resolveUpdateCatalogIds(flags);
 	if (updateSelection.error) {
@@ -1190,10 +1501,46 @@ async function cmdUpdate(flags) {
 		return 1;
 	}
 
+	const legacyPackages = PACKAGES.filter((pkg) =>
+		pkg.id !== COMPOUND_PKG_ID
+		&& updateSelection.ids.includes(pkg.id)
+		&& packageInstallStatus(pkg, updateSelection.sources, flags.local).legacy
+	);
+	const migrationFailure = findCrossScopeMigrationFailure(legacyPackages, updateSelection.sources, flags.local);
+	if (migrationFailure) {
+		console.error(red(`Refusing to migrate ${migrationFailure.pkg.id}: ${migrationFailure.reason}`));
+		return 1;
+	}
+
+	if (!(await ensurePi(flags))) return 127;
+
 	reportLoadOrderNormalization(normalizePackageLoadOrder(flags.local), false);
 
-	if (updateSelection.ids.includes(COMPOUND_PKG_ID)) {
-		console.log(bold("Step 1/2: refresh Compound Engineering"));
+	const refreshCompound = updateSelection.ids.includes(COMPOUND_PKG_ID);
+	const stepCount = Number(legacyPackages.length > 0) + Number(refreshCompound) + 1;
+	let step = 1;
+	const printStep = (message) => {
+		const prefix = stepCount > 1 ? `Step ${step++}/${stepCount}: ` : "";
+		console.log(bold(`${prefix}${message}`));
+	};
+
+	if (legacyPackages.length > 0) {
+		printStep(`migrate legacy catalog package${legacyPackages.length === 1 ? "" : "s"}`);
+		for (const pkg of legacyPackages) {
+			const result = migrateOrInstallPackage(pkg, updateSelection.sources, flags, false);
+			if (!result.ok) {
+				const reason = result.reason ? ` (${result.reason})` : "";
+				const rollback = result.rollbackFailures.length > 0
+					? `; rollback also failed for ${result.rollbackFailures.join(", ")}`
+					: "";
+				console.error(red(`  ✗ failed to migrate ${pkg.id}${reason}${rollback}`));
+				return 1;
+			}
+		}
+	}
+
+	if (refreshCompound) {
+		printStep("refresh Compound Engineering");
 		const installCode = await cmdInstall({
 			...flags,
 			command: "install",
@@ -1203,12 +1550,14 @@ async function cmdUpdate(flags) {
 			forceIds: [COMPOUND_PKG_ID],
 		});
 		if (installCode !== 0) return installCode;
-		console.log(bold("\nStep 2/2: pi update"));
-	} else {
-		console.log(bold("pi update"));
 	}
 
-	return runPi(flags.local ? ["update", "--extensions"] : ["update"]);
+	if (stepCount > 1) console.log("");
+	const updateArgs = flags.local
+		? ["update", "--extensions", ...(piSupportsApprovalFlag() ? ["--approve"] : [])]
+		: ["update", ...(piSupportsUpdateAll() ? ["--all"] : [])];
+	printStep(`pi ${updateArgs.join(" ")}`);
+	return runPi(updateArgs);
 }
 
 // ---------------------------------------------------------------------------
@@ -1229,9 +1578,8 @@ function cmdDoctor(flags) {
 	};
 
 	printHeader("Environment");
-	const nodeMajor = Number(process.versions.node.split(".")[0]);
-	if (Number.isFinite(nodeMajor) && nodeMajor >= 18) pass(`Node ${process.versions.node}`);
-	else fail(`Node ${process.versions.node} — LazyPi requires Node >= 18`);
+	if (isSupportedNodeVersion(process.versions.node)) pass(`Node ${process.versions.node}`);
+	else fail(`Node ${process.versions.node} — LazyPi and current Pi require Node >= ${MIN_NODE_VERSION}`);
 
 	if (hasCmd("npm")) pass("npm is on PATH");
 	else fail("npm is not on PATH — LazyPi can't install Pi for you");
@@ -1365,9 +1713,11 @@ async function cmdRemove(flags, targets) {
 				...findLegacyInstalledSources(pkg, installedSources),
 			]
 			: [source];
-		const uniqueSources = [...new Set(sourcesToRemove.length > 0 ? sourcesToRemove : [source])];
+		const uniqueSources = dedupeSourcesByPackageIdentity(sourcesToRemove.length > 0 ? sourcesToRemove : [source]);
 		for (const resolvedSource of uniqueSources) {
-			const piArgs = flags.local ? ["remove", "-l", resolvedSource] : ["remove", resolvedSource];
+			const piArgs = flags.local
+				? ["remove", "-l", ...(piSupportsApprovalFlag() ? ["--approve"] : []), resolvedSource]
+				: ["remove", resolvedSource];
 			const result = spawnCommand("pi", piArgs, { stdio: "inherit" });
 			if (result.status !== 0) {
 				console.error(red(`Failed to remove ${target}`));

--- a/docs/docs/first-steps.html
+++ b/docs/docs/first-steps.html
@@ -88,7 +88,7 @@ pi</code></pre>
     <h2>6. Update later</h2>
     <pre><code>npx @robzolkos/lazypi update</code></pre>
     <p>
-      Run Pi's updater to pull in upstream updates for installed packages.
+      Migrate legacy LazyPi catalog sources, refresh Compound Engineering when installed, and update Pi plus installed packages.
     </p>
 
     <h2>7. Diagnose issues</h2>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -92,7 +92,7 @@ description: "LazyPi documentation — one command to get a complete Pi coding a
         </tr>
         <tr>
           <td><code>npx @robzolkos/lazypi update</code></td>
-          <td>Run <code>pi update</code> for installed packages</td>
+          <td>Migrate legacy catalog sources and update Pi plus installed packages</td>
         </tr>
         <tr>
           <td><code>npx @robzolkos/lazypi remove</code></td>

--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -8,7 +8,7 @@ description: "How to install LazyPi and get your Pi coding agent set up."
 
     <h2>Prerequisites</h2>
     <ul>
-      <li>Node.js 18 or later</li>
+      <li>Node.js 22.19 or later</li>
       <li>npm (bundled with Node.js)</li>
       <li><strong>Optional:</strong> Bun, if you want the official Compound Engineering package from Every</li>
     </ul>

--- a/docs/docs/packages/claude-cli.html
+++ b/docs/docs/packages/claude-cli.html
@@ -10,12 +10,12 @@ title: "Claude Code CLI — LazyPi Docs"
       Pi-claude-cli registers a custom Pi provider named <code>pi-claude-cli</code>. When you select one of its Claude models in <code>/model</code>, Pi sends model requests through the local <code>claude</code> command instead of a direct Anthropic API key.
     </p>
     <p>
-      Each turn runs Claude Code CLI in stream-json mode, streams text and thinking back into Pi, and lets Pi execute tool calls natively. The extension also resumes Claude Code CLI sessions between turns and exposes custom Pi tools to Claude through a schema-only MCP bridge.
+      Each turn runs Claude Code CLI in stream-json mode and streams text, thinking, and activity back into Pi. Claude Code owns its built-in tool loop and session, while custom tools registered by Pi extensions return to Pi for execution through a schema-only MCP bridge.
     </p>
 
     <h2>Why it's included</h2>
     <p>
-      Many Pi users already have Claude Code authenticated through a Claude Pro or Max subscription. Claude Code CLI makes that subscription usable as a Pi backend without setting up separate Anthropic API billing, while still keeping Pi's native tools, UI, and package ecosystem in charge.
+      Many Pi users already have Claude Code authenticated through a Claude Pro or Max subscription. Claude Code CLI makes that subscription usable as a Pi backend without setting up separate Anthropic API billing, while retaining Pi's UI, custom tools, and package ecosystem.
     </p>
     <p>
       It fits LazyPi as a practical bridge: install the package, make sure Claude Code CLI is available and authenticated, then pick the Claude model provider from Pi's normal model selector.
@@ -39,14 +39,30 @@ title: "Claude Code CLI — LazyPi Docs"
           <td>Select in Pi</td>
           <td>Open <code>/model</code> and choose a Claude model under the <code>pi-claude-cli</code> provider</td>
         </tr>
+        <tr>
+          <td>Use only Pi-configured MCP servers</td>
+          <td>Set <code>PI_CLAUDE_CLI_STRICT_MCP=1</code> before launching Pi</td>
+        </tr>
+        <tr>
+          <td>Exclude Claude project and user settings</td>
+          <td>Set <code>PI_CLAUDE_CLI_HERMETIC=1</code> before launching Pi</td>
+        </tr>
       </tbody>
     </table>
     <p>
       The provider depends on <code>claude</code> being on your <code>PATH</code>. If Claude Code CLI is missing or not authenticated, the extension logs setup instructions and Pi can continue using your other configured providers.
     </p>
+    <div class="callout">
+      <p><strong>Tool security:</strong> The provider automatically approves Claude-native file, shell, web, sub-agent, and user-configured MCP tool requests so Claude Code can own its tool loop. These calls run outside Pi tool-call hooks; configure Claude Code <code>PreToolUse</code> hooks when you need guards. Custom Pi tools still return to Pi for execution. Strict MCP mode excludes user and project MCP servers. Hermetic mode also excludes Claude settings, hooks, memory, and project instructions, so review that trade-off before enabling it.</p>
+    </div>
+
+    <h2>Existing installations</h2>
+    <p>
+      <code>npx @robzolkos/lazypi update</code> migrates the original <code>npm:pi-claude-cli</code> source to the maintained fork. LazyPi currently uses the reviewed <code>npm:@saccolabs/pi-claude-cli@0.6.1</code> release, installs it before removing the original source, and keeps an installed source available if migration cleanup fails.
+    </p>
 
     <div class="learn-more">
-      <a href="https://github.com/rchern/pi-claude-cli" target="_blank" rel="noopener">→ GitHub — rchern/pi-claude-cli</a>
+      <a href="https://github.com/agustinsacco/pi-claude-cli" target="_blank" rel="noopener">→ GitHub — agustinsacco/pi-claude-cli</a>
     </div>
 
     <nav class="prev-next">

--- a/docs/docs/updating.html
+++ b/docs/docs/updating.html
@@ -9,7 +9,7 @@ description: "How to update your LazyPi packages."
     <h2>Update installed packages</h2>
     <pre><code>npx @robzolkos/lazypi update</code></pre>
     <p>
-      This runs Pi's updater for installed package changes.
+      This reconciles LazyPi's installed catalog sources and runs Pi's full updater.
     </p>
 
     <h2>What the update does</h2>
@@ -17,12 +17,16 @@ description: "How to update your LazyPi packages."
       When you run <code>update</code>, LazyPi:
     </p>
     <ol>
+      <li>Migrates installed legacy catalog sources to their current maintained sources</li>
       <li>Refreshes Compound Engineering when it is installed</li>
-      <li>Runs <code>pi update</code> for installed Pi packages</li>
+      <li>Updates Pi itself and installed Pi packages</li>
       <li>Reports what changed</li>
     </ol>
     <p>
-      Update preserves your selected catalog footprint.
+      Update preserves your selected catalog footprint. A replacement installs successfully before LazyPi removes its legacy source. If cleanup fails, LazyPi keeps an installed source available and reports the migration failure.
+    </p>
+    <p>
+      When an identity-changing legacy source is configured in both global and current-project settings, LazyPi keeps both settings unchanged. Remove the duplicate from one scope, then rerun the update for the remaining scope.
     </p>
 
     <nav class="prev-next">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -68,7 +68,7 @@ extra_css: /assets/css/faq.css
   <div class="faq-item">
     <div class="faq-q">How do I keep everything up to date?</div>
     <div class="faq-a">
-      Run <code>npx @robzolkos/lazypi update</code>. This runs Pi's updater to pull in upstream changes for installed Pi packages.
+      Run <code>npx @robzolkos/lazypi update</code>. LazyPi migrates legacy catalog sources, refreshes Compound Engineering when installed, and runs Pi's full updater for Pi itself and installed packages.
     </div>
   </div>
 
@@ -89,7 +89,7 @@ extra_css: /assets/css/faq.css
   <div class="faq-item">
     <div class="faq-q">Does it work on Windows, Mac, and Linux?</div>
     <div class="faq-a">
-      LazyPi requires Node.js 18+ and works anywhere Pi does — macOS, Linux, and Windows (via WSL or a Node-compatible shell). If you hit a platform-specific issue, run <code>npx @robzolkos/lazypi doctor</code> first, then <a href="https://github.com/robzolkos/lazypi/issues" target="_blank">open an issue</a>.
+      LazyPi requires Node.js 22.19+ and works anywhere Pi does — macOS, Linux, and Windows (via WSL or a Node-compatible shell). If you hit a platform-specific issue, run <code>npx @robzolkos/lazypi doctor</code> first, then <a href="https://github.com/robzolkos/lazypi/issues" target="_blank">open an issue</a>.
     </div>
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -204,11 +204,11 @@ og_image: /og.png
         <div class="catalog-desc">Prompt templates with model, skill, and thinking frontmatter</div>
         <div class="catalog-author">by nicobailon</div>
       </a>
-      <a class="catalog-card" href="https://github.com/rchern/pi-claude-cli" target="_blank" rel="noopener">
+      <a class="catalog-card" href="https://github.com/agustinsacco/pi-claude-cli" target="_blank" rel="noopener">
         <span class="catalog-tag core">core</span>
-        <div class="catalog-name">pi-claude-cli</div>
+        <div class="catalog-name">@saccolabs/pi-claude-cli</div>
         <div class="catalog-desc">Use Claude Code CLI auth as a Pi model provider</div>
-        <div class="catalog-author">by rchern</div>
+        <div class="catalog-author">by agustinsacco</div>
       </a>
       <a class="catalog-card" href="https://github.com/backnotprop/plannotator/tree/main/apps/pi-extension" target="_blank" rel="noopener">
         <span class="catalog-tag ui">ui</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "lazypi": "bin/lazypi.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@clack/core": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.19.0"
   },
   "scripts": {
     "docs:serve": "cd docs && bundle exec jekyll serve --livereload",

--- a/test/agent-dir.test.mjs
+++ b/test/agent-dir.test.mjs
@@ -44,12 +44,36 @@ function writeJson(path, value) {
 }
 
 function writeFakePi(bin) {
+	const driverPath = join(bin, "pi-driver.cjs");
+	writeFileSync(driverPath, `
+const { appendFileSync, readFileSync, writeFileSync } = require("node:fs");
+const { join } = require("node:path");
+const args = process.argv.slice(2);
+const command = args[0];
+if (command === "--version") {
+	console.log("pi test");
+	process.exit(0);
+}
+if (command === "update" && args.includes("--help")) {
+	console.log("  --all");
+	process.exit(0);
+}
+if (process.env.PI_TEST_CALLS) appendFileSync(process.env.PI_TEST_CALLS, args.join(" ") + "\\n");
+if (command !== "install" && command !== "remove") process.exit(0);
+const settingsPath = join(process.env.PI_CODING_AGENT_DIR, "settings.json");
+const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+const source = args.at(-1);
+const entrySource = (entry) => typeof entry === "string" ? entry : entry.source;
+if (command === "install") settings.packages.push(source);
+else settings.packages = settings.packages.filter((entry) => entrySource(entry) !== source);
+writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\\n");
+`);
 	if (process.platform === "win32") {
-		writeFileSync(join(bin, "pi.cmd"), "@echo off\r\nif \"%1\"==\"--version\" echo pi test\r\nif defined PI_TEST_CALLS echo %*>>\"%PI_TEST_CALLS%\"\r\nexit /b 0\r\n");
+		writeFileSync(join(bin, "pi.cmd"), `@echo off\r\n"${process.execPath}" "${driverPath}" %*\r\n`);
 		return;
 	}
 	const piPath = join(bin, "pi");
-	writeFileSync(piPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'pi test'; fi\nif [ -n \"$PI_TEST_CALLS\" ]; then printf '%s\\n' \"$*\" >> \"$PI_TEST_CALLS\"; fi\nexit 0\n");
+	writeFileSync(piPath, `#!/bin/sh\nexec "${process.execPath}" "${driverPath}" "$@"\n`);
 	chmodSync(piPath, 0o755);
 }
 
@@ -140,13 +164,26 @@ test("update and remove inspect the custom global settings", (t) => {
 	const updateResult = runCli(["update"], { cwd: workspace, home, agentDir: customAgentDir, bin, callsPath });
 	assert.equal(updateResult.status, 0, `STDOUT:\n${updateResult.stdout}\nSTDERR:\n${updateResult.stderr}`);
 	const customSettings = JSON.parse(readFileSync(join(customAgentDir, "settings.json"), "utf8"));
-	assert.deepEqual(customSettings.packages, [EXTENSION_SETTINGS_SOURCE, POWERBAR_SOURCE, "npm:pi-memory-md"]);
+	assert.deepEqual(customSettings.packages, [
+		EXTENSION_SETTINGS_SOURCE,
+		POWERBAR_SOURCE,
+		"git:github.com/VandeeFeng/pi-memory-md",
+	]);
 	assert.deepEqual(JSON.parse(readFileSync(join(defaultAgentDir, "settings.json"), "utf8")).packages, ["npm:pi-subagents"]);
 
 	const removeResult = runCli(["remove", "memory"], { cwd: workspace, home, agentDir: customAgentDir, bin, callsPath });
 	assert.equal(removeResult.status, 0, `STDOUT:\n${removeResult.stdout}\nSTDERR:\n${removeResult.stderr}`);
 	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
-	assert.deepEqual(calls, ["update", "remove npm:pi-memory-md"]);
+	assert.deepEqual(calls, [
+		"install git:github.com/VandeeFeng/pi-memory-md",
+		"remove npm:pi-memory-md",
+		"update --all",
+		"remove git:github.com/VandeeFeng/pi-memory-md",
+	]);
+	assert.deepEqual(JSON.parse(readFileSync(join(customAgentDir, "settings.json"), "utf8")).packages, [
+		EXTENSION_SETTINGS_SOURCE,
+		POWERBAR_SOURCE,
+	]);
 });
 
 test("--local settings remain independent of PI_CODING_AGENT_DIR", (t) => {

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -30,3 +30,8 @@ test("CI uses LazyPi's supported Node runtime", () => {
 	assert.equal(linuxWorkflow.includes(SUPPORTED_NODE_SETUP), true);
 	assert.equal(windowsWorkflow.split(SUPPORTED_NODE_SETUP).length - 1, 2);
 });
+
+test("full-catalog CI revalidates registry metadata", () => {
+	const linuxWorkflow = readWorkflow(".github/workflows/test.yml");
+	assert.equal(linuxWorkflow.includes("npm_config_prefer_offline"), false);
+});

--- a/test/ci-workflows.test.mjs
+++ b/test/ci-workflows.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 
 const PACKED_CLI_SMOKE_COMMAND = "node scripts/packed-cli-smoke.mjs";
+const SUPPORTED_NODE_SETUP = "node-version: 22.19.0";
 
 function readWorkflow(path) {
 	return readFileSync(path, "utf8");
@@ -21,4 +22,11 @@ test("windows CI workflow smoke-tests the packed CLI artifact in both jobs", () 
 	const workflow = readWorkflow(".github/workflows/windows-smoke.yml");
 	const hits = workflow.split(PACKED_CLI_SMOKE_COMMAND).length - 1;
 	assert.equal(hits, 2);
+});
+
+test("CI uses LazyPi's supported Node runtime", () => {
+	const linuxWorkflow = readWorkflow(".github/workflows/test.yml");
+	const windowsWorkflow = readWorkflow(".github/workflows/windows-smoke.yml");
+	assert.equal(linuxWorkflow.includes(SUPPORTED_NODE_SETUP), true);
+	assert.equal(windowsWorkflow.split(SUPPORTED_NODE_SETUP).length - 1, 2);
 });

--- a/test/claude-cli-migration.test.mjs
+++ b/test/claude-cli-migration.test.mjs
@@ -1,0 +1,535 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { isSupportedNodeVersion, MIN_NODE_VERSION, PACKAGES } from "../bin/lazypi.mjs";
+
+const CLI_PATH = resolve("bin/lazypi.mjs");
+const CURRENT_SOURCE = "npm:@saccolabs/pi-claude-cli@0.6.1";
+const PREVIOUS_CURRENT_SOURCE = "npm:@saccolabs/pi-claude-cli@0.6.0";
+const UNPINNED_CURRENT_SOURCE = "npm:@saccolabs/pi-claude-cli";
+const LEGACY_SOURCE = "npm:pi-claude-cli";
+const PINNED_LEGACY_SOURCE = "npm:pi-claude-cli@0.3.1";
+const CURRENT_AUTORESEARCH_SOURCE = "git:github.com/davebcn87/pi-autoresearch";
+const LEGACY_AUTORESEARCH_SOURCE = "git:github.com/davebcn87/pi-autoresearch@5a29db080131449edc6d25a6b351b12879063366";
+const USER_PINNED_UNPINNED_CATALOG_SOURCE = "npm:pi-subagents@0.13.3";
+const AUTH_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"OPENAI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GEMINI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"TOGETHER_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+];
+
+function createWorkspace(t, packages = []) {
+	const root = mkdtempSync(join(tmpdir(), "lazypi-claude-migration-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const home = join(root, "home");
+	const workspace = join(root, "workspace");
+	const bin = join(root, "bin");
+	const settingsDir = join(home, ".pi", "agent");
+	mkdirSync(settingsDir, { recursive: true });
+	mkdirSync(workspace, { recursive: true });
+	mkdirSync(bin, { recursive: true });
+	writeFileSync(join(settingsDir, "settings.json"), JSON.stringify({ packages }, null, 2) + "\n");
+	return { root, home, workspace, bin, settingsDir };
+}
+
+function writeFakePi(bin) {
+	const driverPath = join(bin, "pi-driver.cjs");
+	writeFileSync(driverPath, `
+const { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } = require("node:fs");
+const { dirname, join } = require("node:path");
+const args = process.argv.slice(2);
+const command = args[0];
+if (command === "install" && args.includes("--help")) {
+	if (process.env.PI_TEST_SUPPORTS_APPROVE !== "0") console.log("  --approve");
+	process.exit(0);
+}
+if (command === "update" && args.includes("--help")) {
+	if (process.env.PI_TEST_SUPPORTS_UPDATE_ALL !== "0") console.log("  --all");
+	process.exit(0);
+}
+appendFileSync(process.env.PI_TEST_CALLS, args.join(" ") + "\\n");
+const source = args.at(-1);
+const failRemoveAfterMutation = command === "remove" && source === process.env.PI_TEST_FAIL_REMOVE_AFTER_MUTATION_SOURCE;
+if (command === "install" && source === process.env.PI_TEST_FAIL_INSTALL_SOURCE) process.exit(41);
+if (command === "remove" && source === process.env.PI_TEST_FAIL_REMOVE_SOURCE) process.exit(42);
+if (command === "--version") {
+	console.log("pi test");
+	process.exit(0);
+}
+if (command !== "install" && command !== "remove") process.exit(0);
+
+const local = args.includes("-l") || args.includes("--local");
+const agentDir = process.env.PI_CODING_AGENT_DIR || join(process.env.HOME, ".pi", "agent");
+const settingsPath = local ? join(process.cwd(), ".pi", "settings.json") : join(agentDir, "settings.json");
+const settings = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, "utf8")) : {};
+const packages = Array.isArray(settings.packages) ? settings.packages : [];
+const entrySource = (entry) => typeof entry === "string" ? entry : entry.source;
+const identity = (value) => {
+	if (value.startsWith("npm:")) {
+		const match = value.slice(4).match(/^(@?[^@]+(?:\\/[^@]+)?)(?:@(.+))?$/);
+		return "npm:" + (match?.[1] || value.slice(4));
+	}
+	if (value.startsWith("git:")) {
+		const body = value.slice(4);
+		const refIndex = body.lastIndexOf("@");
+		return "git:" + (refIndex > body.lastIndexOf("/") ? body.slice(0, refIndex) : body);
+	}
+	return value;
+};
+if (command === "install") {
+	const index = packages.findIndex((entry) => identity(entrySource(entry)) === identity(source));
+	if (index === -1) packages.push(source);
+	else packages[index] = typeof packages[index] === "string" ? source : { ...packages[index], source };
+} else {
+	settings.packages = packages.filter((entry) => identity(entrySource(entry)) !== identity(source));
+}
+if (command === "install") settings.packages = packages;
+mkdirSync(dirname(settingsPath), { recursive: true });
+writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\\n");
+if (failRemoveAfterMutation) process.exit(42);
+`);
+	if (process.platform === "win32") {
+		writeFileSync(join(bin, "pi.cmd"), `@echo off\r\n"${process.execPath}" "${driverPath}" %*\r\n`);
+		return;
+	}
+	const piPath = join(bin, "pi");
+	writeFileSync(piPath, `#!/bin/sh\nexec "${process.execPath}" "${driverPath}" "$@"\n`);
+	chmodSync(piPath, 0o755);
+}
+
+function runCli(t, args, { packages = [], projectPackages, failInstall, failRemove, failRemoveAfterMutation, supportsApprove = true, supportsUpdateAll = true } = {}) {
+	const paths = createWorkspace(t, packages);
+	const callsPath = join(paths.root, "pi-calls.log");
+	writeFileSync(callsPath, "");
+	writeFakePi(paths.bin);
+	if (projectPackages !== undefined) {
+		mkdirSync(join(paths.workspace, ".pi"), { recursive: true });
+		writeFileSync(join(paths.workspace, ".pi", "settings.json"), JSON.stringify({ packages: projectPackages }, null, 2) + "\n");
+	}
+	const env = {
+		...process.env,
+		HOME: paths.home,
+		USERPROFILE: paths.home,
+		PATH: [paths.bin, process.env.PATH].filter(Boolean).join(delimiter),
+		PI_CODING_AGENT_DIR: paths.settingsDir,
+		PI_TEST_CALLS: callsPath,
+		PI_TEST_SUPPORTS_APPROVE: supportsApprove ? "1" : "0",
+		PI_TEST_SUPPORTS_UPDATE_ALL: supportsUpdateAll ? "1" : "0",
+	};
+	if (failInstall) env.PI_TEST_FAIL_INSTALL_SOURCE = failInstall;
+	if (failRemove) env.PI_TEST_FAIL_REMOVE_SOURCE = failRemove;
+	if (failRemoveAfterMutation) env.PI_TEST_FAIL_REMOVE_AFTER_MUTATION_SOURCE = failRemoveAfterMutation;
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		cwd: paths.workspace,
+		env,
+		encoding: "utf8",
+		timeout: 60_000,
+	});
+	if (result.error) throw result.error;
+	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+	const settings = JSON.parse(readFileSync(join(paths.settingsDir, "settings.json"), "utf8"));
+	const projectSettingsPath = join(paths.workspace, ".pi", "settings.json");
+	const projectSettings = projectPackages === undefined
+		? null
+		: JSON.parse(readFileSync(projectSettingsPath, "utf8"));
+	return { result, calls, settings, projectSettings };
+}
+
+function assertSuccess(result) {
+	assert.equal(result.status, 0, `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+}
+
+test("migration tests isolate custom agent directories from the ambient environment", { concurrency: false }, (t) => {
+	const ambientRoot = mkdtempSync(join(tmpdir(), "lazypi-ambient-agent-dir-"));
+	t.after(() => rmSync(ambientRoot, { recursive: true, force: true }));
+	const ambientSettingsPath = join(ambientRoot, "settings.json");
+	const sentinel = JSON.stringify({ sentinel: true, packages: [LEGACY_SOURCE] }, null, 2) + "\n";
+	writeFileSync(ambientSettingsPath, sentinel);
+
+	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+	process.env.PI_CODING_AGENT_DIR = ambientRoot;
+	try {
+		const { result } = runCli(t, ["install", "--yes", "--only", "claude-cli"]);
+		assertSuccess(result);
+	} finally {
+		if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+	}
+
+	assert.equal(readFileSync(ambientSettingsPath, "utf8"), sentinel);
+});
+
+test("Claude CLI catalog uses the reviewed maintained fork release and recognizes the original source", () => {
+	const pkg = PACKAGES.find(({ id }) => id === "claude-cli");
+	assert.equal(pkg?.source, CURRENT_SOURCE);
+	assert.deepEqual(pkg?.legacySources, [LEGACY_SOURCE]);
+});
+
+test("Claude CLI docs describe the observer-mode tool boundary consistently", () => {
+	const docs = readFileSync("docs/docs/packages/claude-cli.html", "utf8");
+	assert.doesNotMatch(docs, /Pi's native tools[^.]*in charge/);
+	assert.match(docs, /Claude Code owns its built-in tool loop/);
+	assert.match(docs, /These calls run outside Pi tool-call hooks/);
+});
+
+test("user-facing docs describe migration and full update behavior", () => {
+	for (const path of ["README.md", "docs/docs/index.html", "docs/docs/first-steps.html", "docs/docs/updating.html", "docs/faq.html"]) {
+		const content = readFileSync(path, "utf8");
+		assert.match(content, /migrat/i, `${path} should describe catalog migration`);
+		assert.match(content, /update Pi|Pi itself/i, `${path} should describe updating Pi itself`);
+	}
+	const help = spawnSync(process.execPath, [CLI_PATH, "--help"], { encoding: "utf8" });
+	assertSuccess(help);
+	assert.match(help.stdout, /update\s+Migrate catalog sources and update Pi plus installed packages/);
+});
+
+test("supported Node version matches current Pi's runtime floor", () => {
+	assert.equal(MIN_NODE_VERSION, "22.19.0");
+	assert.equal(isSupportedNodeVersion("22.18.9"), false);
+	assert.equal(isSupportedNodeVersion("22.19.0-rc.1"), false);
+	assert.equal(isSupportedNodeVersion("v22.19.0"), true);
+	assert.equal(isSupportedNodeVersion("22.19.1-rc.1"), true);
+	assert.equal(isSupportedNodeVersion("22.19.1"), true);
+	assert.equal(isSupportedNodeVersion("23.0.0"), true);
+	assert.equal(isSupportedNodeVersion("invalid"), false);
+});
+
+test("status reports the original package as legacy with an update path", (t) => {
+	const { result } = runCli(t, ["status"], { packages: [LEGACY_SOURCE] });
+	assertSuccess(result);
+	assert.match(result.stdout, /Installed with legacy catalog sources \(1\)/);
+	assert.match(result.stdout, /claude-cli\s+npm:pi-claude-cli — run `lazypi update` to migrate/);
+	assert.doesNotMatch(result.stdout, new RegExp(`Other Pi packages outside the LazyPi catalog \\(1\\)`));
+});
+
+test("maintained-package version variants are reported as requiring migration", (t) => {
+	for (const source of [PREVIOUS_CURRENT_SOURCE, UNPINNED_CURRENT_SOURCE]) {
+		const { result } = runCli(t, ["status"], { packages: [source] });
+		assertSuccess(result);
+		assert.match(result.stdout, /Installed with legacy catalog sources \(1\)/);
+		assert.match(result.stdout, /claude-cli\s+/);
+		assert.ok(result.stdout.includes(`${source} — run \`lazypi update\` to migrate`));
+		assert.doesNotMatch(result.stdout, /Other Pi packages outside the LazyPi catalog \(1\)/);
+	}
+});
+
+test("update reconciles maintained-package variants to the reviewed pin", (t) => {
+	const previousEntry = { source: PREVIOUS_CURRENT_SOURCE, autoload: false, extensions: [] };
+	const previous = runCli(t, ["update", "--only", "claude-cli"], { packages: [previousEntry] });
+	assertSuccess(previous.result);
+	assert.deepEqual(previous.calls, [`install ${CURRENT_SOURCE}`, "update --all"]);
+	assert.deepEqual(previous.settings.packages, [{ ...previousEntry, source: CURRENT_SOURCE }]);
+
+	const unpinned = runCli(t, ["update", "--only", "claude-cli"], { packages: [UNPINNED_CURRENT_SOURCE] });
+	assertSuccess(unpinned.result);
+	assert.deepEqual(unpinned.calls, [`install ${CURRENT_SOURCE}`, "update --all"]);
+	assert.deepEqual(unpinned.settings.packages, [CURRENT_SOURCE]);
+});
+
+test("reviewed-pin reconciliation does not overwrite user pins for unpinned catalog packages", (t) => {
+	const status = runCli(t, ["status"], { packages: [USER_PINNED_UNPINNED_CATALOG_SOURCE] });
+	assertSuccess(status.result);
+	assert.match(status.result.stdout, /Installed with legacy catalog sources \(0\)/);
+	assert.match(status.result.stdout, /Other Pi packages outside the LazyPi catalog \(1\)/);
+
+	const update = runCli(t, ["update", "--only", "subagents"], { packages: [USER_PINNED_UNPINNED_CATALOG_SOURCE] });
+	assertSuccess(update.result);
+	assert.deepEqual(update.calls, ["update --all"]);
+	assert.deepEqual(update.settings.packages, [USER_PINNED_UNPINNED_CATALOG_SOURCE]);
+});
+
+test("versioned original sources are recognized, migrated, and removable", (t) => {
+	const status = runCli(t, ["status"], { packages: [PINNED_LEGACY_SOURCE] });
+	assertSuccess(status.result);
+	assert.match(status.result.stdout, /Installed with legacy catalog sources \(1\)/);
+	assert.doesNotMatch(status.result.stdout, /Other Pi packages outside the LazyPi catalog \(1\)/);
+
+	const update = runCli(t, ["update", "--only", "claude-cli"], { packages: [PINNED_LEGACY_SOURCE] });
+	assertSuccess(update.result);
+	assert.deepEqual(update.calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${PINNED_LEGACY_SOURCE}`,
+		"update --all",
+	]);
+	assert.deepEqual(update.settings.packages, [CURRENT_SOURCE]);
+
+	const remove = runCli(t, ["remove", "claude-cli"], { packages: [PINNED_LEGACY_SOURCE] });
+	assertSuccess(remove.result);
+	assert.deepEqual(remove.calls, [`remove ${PINNED_LEGACY_SOURCE}`]);
+	assert.deepEqual(remove.settings.packages, []);
+});
+
+test("fresh install uses the maintained fork", (t) => {
+	const { result, calls } = runCli(t, ["install", "--yes", "--only", "claude-cli"]);
+	assertSuccess(result);
+	assert.deepEqual(calls, [`install ${CURRENT_SOURCE}`]);
+});
+
+test("install migrates only after the replacement installs successfully", (t) => {
+	const { result, calls } = runCli(t, ["install", "--yes", "--only", "claude-cli"], { packages: [LEGACY_SOURCE] });
+	assertSuccess(result);
+	assert.deepEqual(calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${LEGACY_SOURCE}`,
+	]);
+});
+
+test("migration preserves package filters on the replacement", (t) => {
+	const legacyEntry = {
+		source: LEGACY_SOURCE,
+		autoload: false,
+		extensions: [],
+		themes: ["+themes/custom.json"],
+	};
+	const { result, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: ["./before", legacyEntry, "./after"],
+	});
+	assertSuccess(result);
+	assert.deepEqual(settings.packages, ["./before", { ...legacyEntry, source: CURRENT_SOURCE }, "./after"]);
+});
+
+test("migration preserves configured legacy filters when the replacement already exists", (t) => {
+	const legacyEntry = {
+		source: LEGACY_SOURCE,
+		autoload: false,
+		extensions: [],
+		themes: ["+themes/custom.json"],
+	};
+	const { result, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [CURRENT_SOURCE, legacyEntry],
+	});
+	assertSuccess(result);
+	assert.deepEqual(settings.packages, [{ ...legacyEntry, source: CURRENT_SOURCE }]);
+});
+
+test("migration keeps replacement filters when both sources are configured", (t) => {
+	const currentEntry = { source: CURRENT_SOURCE, autoload: false, extensions: ["+index.ts"] };
+	const legacyEntry = { source: LEGACY_SOURCE, themes: ["+themes/legacy.json"] };
+	const { result, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [legacyEntry, currentEntry],
+	});
+	assertSuccess(result);
+	assert.deepEqual(settings.packages, [currentEntry]);
+});
+
+test("identity-changing migration refuses mixed global and project legacy entries", (t) => {
+	const projectOverride = { source: LEGACY_SOURCE, autoload: false, extensions: [] };
+	const globalMigration = runCli(t, ["update", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		projectPackages: [projectOverride],
+	});
+	assert.equal(globalMigration.result.status, 1);
+	assert.deepEqual(globalMigration.calls, []);
+	assert.deepEqual(globalMigration.settings.packages, [LEGACY_SOURCE]);
+	assert.deepEqual(globalMigration.projectSettings.packages, [projectOverride]);
+	assert.match(globalMigration.result.stderr, /also configured in project settings/);
+
+	const localMigration = runCli(t, ["update", "--local", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		projectPackages: [projectOverride],
+	});
+	assert.equal(localMigration.result.status, 1);
+	assert.deepEqual(localMigration.calls, []);
+	assert.deepEqual(localMigration.settings.packages, [LEGACY_SOURCE]);
+	assert.deepEqual(localMigration.projectSettings.packages, [projectOverride]);
+	assert.match(localMigration.result.stderr, /also configured in global settings/);
+});
+
+test("same-repository git migration does not remove the replacement", (t) => {
+	const { result, calls, settings } = runCli(t, ["install", "--yes", "--only", "autoresearch"], {
+		packages: [LEGACY_AUTORESEARCH_SOURCE],
+	});
+	assertSuccess(result);
+	assert.deepEqual(calls, [`install ${CURRENT_AUTORESEARCH_SOURCE}`]);
+	assert.deepEqual(settings.packages, [CURRENT_AUTORESEARCH_SOURCE]);
+});
+
+test("same-identity current and legacy git entries clean up without uninstalling the replacement", (t) => {
+	const legacyEntry = { source: LEGACY_AUTORESEARCH_SOURCE, autoload: false, extensions: [] };
+	const migration = runCli(t, ["install", "--yes", "--only", "autoresearch"], {
+		packages: ["./before", legacyEntry, CURRENT_AUTORESEARCH_SOURCE, "./after"],
+	});
+	assertSuccess(migration.result);
+	assert.deepEqual(migration.calls, []);
+	assert.deepEqual(migration.settings.packages, [
+		"./before",
+		{ ...legacyEntry, source: CURRENT_AUTORESEARCH_SOURCE },
+		"./after",
+	]);
+
+	const removal = runCli(t, ["remove", "autoresearch"], {
+		packages: [CURRENT_AUTORESEARCH_SOURCE, LEGACY_AUTORESEARCH_SOURCE],
+	});
+	assertSuccess(removal.result);
+	assert.deepEqual(removal.calls, [`remove ${CURRENT_AUTORESEARCH_SOURCE}`]);
+	assert.deepEqual(removal.settings.packages, []);
+});
+
+test("same-identity cleanup preserves configured entries regardless of order", (t) => {
+	const legacyEntry = { source: LEGACY_AUTORESEARCH_SOURCE, autoload: false, extensions: [] };
+	const migration = runCli(t, ["install", "--yes", "--only", "autoresearch"], {
+		packages: [CURRENT_AUTORESEARCH_SOURCE, legacyEntry],
+	});
+	assertSuccess(migration.result);
+	assert.deepEqual(migration.calls, []);
+	assert.deepEqual(migration.settings.packages, [{ ...legacyEntry, source: CURRENT_AUTORESEARCH_SOURCE }]);
+});
+
+test("same-identity cleanup keeps current-source filters when duplicate entries conflict", (t) => {
+	const currentEntry = { source: CURRENT_AUTORESEARCH_SOURCE, extensions: ["+index.ts"] };
+	const legacyEntry = { source: LEGACY_AUTORESEARCH_SOURCE, autoload: false, extensions: [] };
+	const migration = runCli(t, ["install", "--yes", "--only", "autoresearch"], {
+		packages: [legacyEntry, currentEntry],
+	});
+	assertSuccess(migration.result);
+	assert.deepEqual(migration.settings.packages, [currentEntry]);
+});
+
+test("duplicate spellings of one legacy npm package require one removal", (t) => {
+	const { result, calls, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE, PINNED_LEGACY_SOURCE],
+	});
+	assertSuccess(result);
+	assert.deepEqual(calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${LEGACY_SOURCE}`,
+	]);
+	assert.deepEqual(settings.packages, [CURRENT_SOURCE]);
+});
+
+test("install cleans up legacy source when replacement already exists", (t) => {
+	const { result, calls } = runCli(t, ["install", "--yes", "--only", "claude-cli"], { packages: [CURRENT_SOURCE, LEGACY_SOURCE] });
+	assertSuccess(result);
+	assert.deepEqual(calls, [`remove ${LEGACY_SOURCE}`]);
+});
+
+test("failed replacement install leaves the legacy source untouched", (t) => {
+	const { result, calls } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		failInstall: CURRENT_SOURCE,
+	});
+	assert.equal(result.status, 1);
+	assert.deepEqual(calls, [`install ${CURRENT_SOURCE}`]);
+	assert.match(result.stderr, /failed to install claude-cli/);
+});
+
+test("failed legacy removal keeps the replacement available", (t) => {
+	const { result, calls, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		failRemove: LEGACY_SOURCE,
+	});
+	assert.equal(result.status, 1);
+	assert.deepEqual(calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${LEGACY_SOURCE}`,
+	]);
+	assert.deepEqual(settings.packages, [LEGACY_SOURCE, CURRENT_SOURCE]);
+	assert.match(result.stderr, /failed to migrate claude-cli/);
+});
+
+test("partial legacy removal failure keeps the replacement available", (t) => {
+	const { result, calls, settings } = runCli(t, ["install", "--yes", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		failRemoveAfterMutation: LEGACY_SOURCE,
+	});
+	assert.equal(result.status, 1);
+	assert.deepEqual(calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${LEGACY_SOURCE}`,
+	]);
+	assert.deepEqual(settings.packages, [CURRENT_SOURCE]);
+	assert.match(result.stderr, /failed to migrate claude-cli/);
+});
+
+test("update migrates the original source before updating Pi and extensions", (t) => {
+	const { result, calls } = runCli(t, ["update", "--only", "claude-cli"], { packages: [LEGACY_SOURCE] });
+	assertSuccess(result);
+	assert.deepEqual(calls, [
+		`install ${CURRENT_SOURCE}`,
+		`remove ${LEGACY_SOURCE}`,
+		"update --all",
+	]);
+});
+
+test("update remains compatible with Pi versions before the all flag", (t) => {
+	const { result, calls } = runCli(t, ["update", "--only", "claude-cli"], {
+		packages: [CURRENT_SOURCE],
+		supportsUpdateAll: false,
+	});
+	assertSuccess(result);
+	assert.deepEqual(calls, ["update"]);
+});
+
+test("update stops safely when the replacement cannot be installed", (t) => {
+	const { result, calls } = runCli(t, ["update", "--only", "claude-cli"], {
+		packages: [LEGACY_SOURCE],
+		failInstall: CURRENT_SOURCE,
+	});
+	assert.equal(result.status, 1);
+	assert.deepEqual(calls, [`install ${CURRENT_SOURCE}`]);
+	assert.match(result.stderr, /failed to migrate claude-cli/);
+});
+
+test("remove by catalog id still removes the installed legacy source", (t) => {
+	const { result, calls } = runCli(t, ["remove", "claude-cli"], { packages: [LEGACY_SOURCE] });
+	assertSuccess(result);
+	assert.deepEqual(calls, [`remove ${LEGACY_SOURCE}`]);
+});
+
+function runLocalMigration(t, supportsApprove) {
+	const paths = createWorkspace(t);
+	const callsPath = join(paths.root, "pi-calls.log");
+	writeFileSync(callsPath, "");
+	writeFakePi(paths.bin);
+	mkdirSync(join(paths.workspace, ".pi"), { recursive: true });
+	writeFileSync(join(paths.workspace, ".pi", "settings.json"), JSON.stringify({ packages: [LEGACY_SOURCE] }, null, 2) + "\n");
+	const env = {
+		...process.env,
+		HOME: paths.home,
+		USERPROFILE: paths.home,
+		PATH: [paths.bin, process.env.PATH].filter(Boolean).join(delimiter),
+		PI_CODING_AGENT_DIR: paths.settingsDir,
+		PI_TEST_CALLS: callsPath,
+		PI_TEST_SUPPORTS_APPROVE: supportsApprove ? "1" : "0",
+	};
+	for (const key of AUTH_ENV_VARS) delete env[key];
+	const result = spawnSync(process.execPath, [CLI_PATH, "update", "--local", "--only", "claude-cli"], {
+		cwd: paths.workspace,
+		env,
+		encoding: "utf8",
+		timeout: 60_000,
+	});
+	if (result.error) throw result.error;
+	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
+	return { result, calls };
+}
+
+test("local update approves migrations when Pi supports the approval flag", (t) => {
+	const { result, calls } = runLocalMigration(t, true);
+	assertSuccess(result);
+	assert.deepEqual(calls, [
+		`install -l --approve ${CURRENT_SOURCE}`,
+		`remove -l --approve ${LEGACY_SOURCE}`,
+		"update --extensions --approve",
+	]);
+});
+
+test("local update remains compatible with Pi versions before the approval flag", (t) => {
+	const { result, calls } = runLocalMigration(t, false);
+	assertSuccess(result);
+	assert.deepEqual(calls, [
+		`install -l ${CURRENT_SOURCE}`,
+		`remove -l ${LEGACY_SOURCE}`,
+		"update --extensions",
+	]);
+});

--- a/test/load-order.test.mjs
+++ b/test/load-order.test.mjs
@@ -120,5 +120,5 @@ test("update repairs load order before delegating to pi update", () => {
 	const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
 	assert.deepEqual(settings.packages, [EXTENSION_SETTINGS_SOURCE, POWERBAR_SOURCE]);
 	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
-	assert.deepEqual(calls, ["update --extensions"]);
+	assert.deepEqual(calls, ["install --help", "update --extensions"]);
 });

--- a/test/update-selection.test.mjs
+++ b/test/update-selection.test.mjs
@@ -30,7 +30,7 @@ function createWorkspace() {
 
 function writeFakePi(bin, callsPath) {
 	const piPath = join(bin, "pi");
-	writeFileSync(piPath, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${callsPath}"\nexit 0\n`);
+	writeFileSync(piPath, `#!/bin/sh\nif [ "$1" = "update" ] && [ "$2" = "--help" ]; then echo '  --all'; exit 0; fi\nprintf '%s\\n' "$*" >> "${callsPath}"\nexit 0\n`);
 	chmodSync(piPath, 0o755);
 }
 
@@ -51,7 +51,7 @@ function runCli(args, { cwd, home, bin } = {}) {
 	return result;
 }
 
-test("update delegates to pi update without installing the full catalog", () => {
+test("update delegates to Pi's full updater without installing the catalog", () => {
 	const { root, home, workspace, bin } = createWorkspace();
 	const callsPath = join(root, "pi-calls.log");
 	writeFakePi(bin, callsPath);
@@ -63,6 +63,6 @@ test("update delegates to pi update without installing the full catalog", () => 
 	assert.match(result.stdout, /pi update/);
 
 	const calls = readFileSync(callsPath, "utf8").trim().split(/\r?\n/).filter(Boolean);
-	assert.deepEqual(calls, ["update"]);
+	assert.deepEqual(calls, ["update --all"]);
 	assert.doesNotMatch(calls.join("\n"), /install|npm:pi-mcp-adapter|npm:pi-web-access|npm:@devkade\/pi-plan/);
 });


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.100.0
<!-- pr-review-readiness-head: 527b28400b6662795a8f99ba58be8d1610618257 -->

Replace the stale Claude CLI provider with the maintained SaccoLabs fork while preserving an available provider throughout migration. The fork stays pinned to reviewed v0.6.1 because v0.7.0's new IPC path still has an open security-hardening issue.

**Review readiness:** ✅ Yes  
**Risk:** 🔴 High — this changes an authenticated runtime provider, shared package-migration behavior, the Node floor, and which runtime governs native tool execution.  
**Decision:** None — observer mode is accepted, and v0.6.1 remains pinned until the v0.7 IPC boundary is hardened and reviewed.

<details>
<summary>✅ Change — existing installs migrate only after the maintained provider is available</summary>

### Before

```text
lazypi update
└── npm:pi-claude-cli remains stale

legacy migration
└── remove legacy source first
    └── ❌ replacement failure can leave no provider
```

### After

```text
lazypi install/update
├── reconcile maintained-package variants to reviewed v0.6.1
├── install npm:@saccolabs/pi-claude-cli@0.6.1
├── preserve package filters and ordering
├── remove npm:pi-claude-cli only after install succeeds  ← CHANGED
├── retain the replacement if cleanup fails
└── run Pi's full updater
    └── ✅ current Pi uses `pi update --all`
```

`status` identifies original and maintained-package variants that need migration. `remove claude-cli` handles current and legacy sources. Identity-changing migration stops before mutation when the legacy package is configured in both global and project settings, preserving project overrides.

</details>

<details>
<summary>✅ Version and usage coverage — reviewed fork v0.6.1 replaces original v0.3.1</summary>

- **Dependency:** `pi-claude-cli@0.3.1` → `@saccolabs/pi-claude-cli@0.6.1`
- **Role:** direct production Pi extension and Claude Code CLI model provider.
- **Reason:** the original package targets old Pi package names and has unresolved compatibility fixes; the fork supports current Pi and Claude Code CLI.
- **v0.4.0–v0.4.7:** current Pi packages and API registration, Claude Code 2.x compatibility, resume/context handling, thinking streams, rate limits, and system-prompt controls.
- **v0.4.8–v0.4.16:** observer mode plus rate, token, effort, sub-agent, and resumed-prompt corrections.
- **v0.5.0–v0.5.2:** configurable compaction, strict MCP mode/schema refresh, and zero-argument tool support.
- **v0.6.0–v0.6.1:** optional CLI tool-result markers and queued-prompt empty-reply correction.
- **Breaking behavior:** Claude Code owns native file, shell, web, sub-agent, and user-MCP execution. Pi hooks govern custom Pi tools handed back to Pi but do not intercept Claude-native calls; the package documentation discloses this boundary.
- **Runtime:** the fork requires Node 22+, and current Pi requires Node `>=22.19.0`; manifest, lockfile, doctor, help, README, site docs, tests, and CI use that floor.
- **Security:** v0.6.1 is signed and provenance-attested, has no install/postinstall lifecycle script, and has one direct runtime dependency (`cross-spawn ^7.0.6`). v0.7.0 remains excluded pending [IPC hardening #35](https://github.com/agustinsacco/pi-claude-cli/issues/35).

| LazyPi boundary | Evidence |
|---|---|
| Catalog source and legacy identity | catalog regression |
| Fresh install and real provider discovery | migration suite and isolated real-Pi validation |
| Status and maintained-version reconciliation | status/update variant regressions |
| Filters, ordering, duplicates, and repeated invocation | migration-state regressions |
| Install and partial-cleanup failures | before-mutation and mutate-then-fail regressions |
| Global/project scope and custom agent directory | cross-scope and `PI_CODING_AGENT_DIR` regressions |
| Removal by catalog ID | legacy removal regression |
| Current and older Pi command forms | `--all`, `--approve`, and compatibility fallback regressions |

</details>

<details>
<summary>✅ Evidence — focused behavior, full suite, packaging, docs, and real Pi discovery pass</summary>

```text
npm test
61 passed, 0 failed

node scripts/packed-cli-smoke.mjs
passed; packed `lazypi --help` executed successfully

cd docs && bundle exec jekyll build
passed
```

Isolated real-Pi migration:

```text
start:   npm:pi-claude-cli
install: npm:@saccolabs/pi-claude-cli@0.6.1 succeeded
cleanup: npm:pi-claude-cli removed
result:  ["npm:@saccolabs/pi-claude-cli@0.6.1"]
discovery: `pi --list-models pi-claude-cli` listed the provider's model catalog
```

Package verification:

- npm reports v0.6.1 registry signature, provenance, Node `>=22`, and `cross-spawn ^7.0.6` as its only direct dependency.
- The exact release has no install/postinstall lifecycle script.
- The newer v0.7.0 is currently npm `latest` and is deliberately prevented from replacing the reviewed pin.

</details>

<details>
<summary>✅ Scope — runtime migration and CI reliability are separated into two ordered commits</summary>

1. [`fix: migrate Claude CLI provider safely`](https://github.com/robzolkos/LazyPi/commit/761a1dca420d41cffc02e976f8b2dd0a92d3b2af) — provider source, safe shared migration, full-update compatibility, Node requirement, regression coverage, and user documentation.
2. [`ci: stabilize full catalog integration`](https://github.com/robzolkos/LazyPi/commit/527b28400b6662795a8f99ba58be8d1610618257) — longer full-catalog timeout and shared npm/Bun caches for integration homes.

No authentication data, provider protocol, or Claude extension code is vendored. No automatic move to v0.7.0 is included.

</details>

<details>
<summary>✅ Delivery — migration preserves user state and fails before destructive ambiguity</summary>

- Replacement installation failure leaves the legacy source untouched.
- Legacy cleanup failure leaves the replacement installed and reports failure; previously removed legacy identities are restored when applicable.
- Existing replacement filters take precedence; otherwise configured legacy filters transfer to the replacement.
- Mixed global/project legacy identities are rejected before Pi installation, settings writes, or package removal.
- Maintained-package version variants reconcile to v0.6.1 only for pinned catalog entries; user pins for unpinned catalog packages remain unchanged.
- No deployment credentials, feature flags, backfills, or scheduled work are required.

Rollback requires reinstalling and confirming the original source before removing the maintained fork; no automatic downgrade is performed. This release continues to recognize the original source as legacy for forward recovery.

</details>

<details>
<summary>⚠️ Review focus — migration failure handling and the temporary security pin need human judgment</summary>

Start with the install-before-remove and cleanup-failure behavior in `migrateOrInstallPackage`, then confirm the v0.6.1 pin is the right boundary while upstream IPC hardening remains open.

The fork remains young and single-maintainer. Registry provenance, the small dependency surface, cross-platform upstream CI, exact-version pinning, and local regression coverage reduce but do not eliminate supply-chain risk.

</details>

<details>
<summary>✅ Review path — runtime behavior first, then proof, compatibility, and CI</summary>

1. [`bin/lazypi.mjs`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/bin/lazypi.mjs) — catalog identity, migration transaction, scope checks, updater compatibility, and Node guard.
2. [`test/claude-cli-migration.test.mjs`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/test/claude-cli-migration.test.mjs) — source variants, state preservation, partial failures, scope, update, and removal proof.
3. [`docs/docs/packages/claude-cli.html`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/docs/docs/packages/claude-cli.html), [`docs/docs/updating.html`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/docs/docs/updating.html), and [`README.md`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/README.md) — provider boundary, migration guarantees, full-update behavior, and runtime requirement.
4. [Linux CI](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/.github/workflows/test.yml), [Windows smoke](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/.github/workflows/windows-smoke.yml), and [`test/ci-workflows.test.mjs`](https://github.com/robzolkos/LazyPi/blob/527b28400b6662795a8f99ba58be8d1610618257/test/ci-workflows.test.mjs) — Node compatibility and full-catalog reliability.

**Origin and supporting links:** [LazyPi issue #78](https://github.com/robzolkos/LazyPi/issues/78) · [fork v0.6.1](https://github.com/agustinsacco/pi-claude-cli/releases/tag/v0.6.1) · [upstream IPC hardening #35](https://github.com/agustinsacco/pi-claude-cli/issues/35) · [original-to-fork comparison](https://github.com/agustinsacco/pi-claude-cli/compare/rchern:main...v0.6.1)

</details>



Closes #78
